### PR TITLE
KOGITO-8535 Deploy pipelines: Push built image

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -159,15 +159,24 @@ pipeline {
                 script {
                     helper.loginRegistry()
 
+                    // If not release, push built image
+                    // So the user using the `operator.yaml on branch can use an existing image`
+                    if (!helper.isRelease()) {
+                        container.pushImage(getBuiltImage())
+                    }
+
+                    // Tag with given parameter tag
                     container.tagImage(getBuiltImage(), helper.getImageFullTag(env.OPERATOR_IMAGE_NAME))
                     container.pushImage(helper.getImageFullTag(env.OPERATOR_IMAGE_NAME))
 
+                    // Tag with `latest` tag if asked for as parameter
                     if (helper.isDeployLatestTag()) {
                         String finalFullImage = helper.getImageFullTag(env.OPERATOR_IMAGE_NAME, defaultImageParamsPrefix, 'latest')
                         container.tagImage(getBuiltImage(), finalFullImage)
                         container.pushImage(finalFullImage)
                     }
 
+                    // Tag with reduced tag, aka X.Y, if it can be guessed from given tag parameter
                     String reducedTag = helper.getReducedTag()
                     if (reducedTag) {
                         String finalFullImage = helper.getImageFullTag(env.OPERATOR_IMAGE_NAME, defaultImageParamsPrefix, reducedTag)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # kiegroup.org/kogito-serverless-operator-bundle:$VERSION and kiegroup.org/kogito-serverless-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/kiegroup/kogito-serverless-operator
+IMAGE_TAG_BASE ?= quay.io/kiegroup/kogito-serverless-operator-nightly
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
@@ -290,8 +290,9 @@ clean:
 
 .PHONY: bump-version
 new_version = ""
+snapshot = ""
 bump-version:
-	./hack/bump-version.sh $(new_version)
+	./hack/bump-version.sh $(new_version) $(snapshot)
 
 install-operator-sdk:
 	./hack/ci/install-operator-sdk.sh

--- a/bundle/manifests/kogito-serverless-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kogito-serverless-operator.clusterserviceversion.yaml
@@ -347,7 +347,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kiegroup/kogito-serverless-operator:2.0.0-snapshot
+                image: quay.io/kiegroup/kogito-serverless-operator-nightly:2.0.0-snapshot
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -19,7 +19,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/kiegroup/kogito-serverless-operator
+  newName: quay.io/kiegroup/kogito-serverless-operator-nightly
   newTag: 2.0.0-snapshot
 # Patching the manager deployment file to add an env var with the operator namespace in
 patchesJson6902:

--- a/operator.yaml
+++ b/operator.yaml
@@ -2946,7 +2946,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kiegroup/kogito-serverless-operator:2.0.0-snapshot
+        image: quay.io/kiegroup/kogito-serverless-operator-nightly:2.0.0-snapshot
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-8535

On branches nightly, the version is set with `-snapshot` version so we just push the nightly image as it is built.
The default image name on branch will be nightly.

Once a release is done, the imageTagBase will be changed to prod one.
And we push all together.