### PR TITLE
[KOGITO-8642] - Introduce health checks to the default Deployment

### DIFF
--- a/api/v1alpha08/zz_generated.deepcopy.go
+++ b/api/v1alpha08/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@
 package v1alpha08
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/api/v1alpha08/zz_generated.deepcopy.go
+++ b/api/v1alpha08/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@
 package v1alpha08
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/controllers/profiles/object_creators.go
+++ b/controllers/profiles/object_creators.go
@@ -60,7 +60,8 @@ const (
 )
 
 var defaultApplicationProperties = "quarkus.http.port=" + strconv.Itoa(defaultHTTPWorkflowPort) + "\n" +
-	"quarkus.http.host=0.0.0.0\n"
+	"quarkus.http.host=0.0.0.0\n" +
+	"org.kie.kogito.addons.knative.health-enabled=false\n"
 
 // objectCreator is the func that creates the initial reference object, if the object doesn't exist in the cluster, this one is created.
 // Can be used as a reference to keep the object immutable

--- a/controllers/profiles/object_creators_test.go
+++ b/controllers/profiles/object_creators_test.go
@@ -27,12 +27,12 @@ import (
 func Test_ensureWorkflowPropertiesConfigMapMutator(t *testing.T) {
 	workflow := test.GetKogitoServerlessWorkflow("../../config/samples/"+test.KogitoServerlessWorkflowSampleDevModeYamlCR, t.Name())
 	// can't be new
-	cm, _ := workflowPropsConfigMapCreator(workflow)
+	cm, _ := workflowDevPropsConfigMapCreator(workflow)
 	cm.SetUID("1")
 	cm.SetResourceVersion("1")
 	reflectCm := cm.(*v1.ConfigMap)
 
-	visitor := ensureWorkflowPropertiesConfigMapMutator(workflow)
+	visitor := ensureWorkflowDevPropertiesConfigMapMutator(workflow)
 	mutateFn := visitor(cm)
 
 	assert.NoError(t, mutateFn())

--- a/controllers/profiles/reconciler_dev.go
+++ b/controllers/profiles/reconciler_dev.go
@@ -83,7 +83,7 @@ func newDevelopmentObjectEnsurers(support *stateSupport) *devProfileObjectEnsure
 		deployment:          newObjectEnsurer(support.client, support.logger, defaultDeploymentCreator),
 		service:             newObjectEnsurer(support.client, support.logger, defaultServiceCreator),
 		definitionConfigMap: newObjectEnsurer(support.client, support.logger, workflowDefConfigMapCreator),
-		propertiesConfigMap: newObjectEnsurer(support.client, support.logger, workflowPropsConfigMapCreator),
+		propertiesConfigMap: newObjectEnsurer(support.client, support.logger, workflowDevPropsConfigMapCreator),
 	}
 }
 
@@ -113,7 +113,7 @@ func (e *ensureRunningDevWorkflowReconciliationState) Do(ctx context.Context, wo
 	}
 	objs = append(objs, flowDefCM)
 
-	propsCM, _, err := e.ensurers.propertiesConfigMap.ensure(ctx, workflow, ensureWorkflowPropertiesConfigMapMutator(workflow))
+	propsCM, _, err := e.ensurers.propertiesConfigMap.ensure(ctx, workflow, ensureWorkflowDevPropertiesConfigMapMutator(workflow))
 	if err != nil {
 		return ctrl.Result{Requeue: false}, objs, err
 	}

--- a/controllers/profiles/reconciler_dev.go
+++ b/controllers/profiles/reconciler_dev.go
@@ -122,7 +122,8 @@ func (e *ensureRunningDevWorkflowReconciliationState) Do(ctx context.Context, wo
 	deployment, _, err := e.ensurers.deployment.ensure(ctx, workflow,
 		defaultDeploymentMutateVisitor(workflow),
 		naiveApplyImageDeploymentMutateVisitor(defaultKogitoServerlessWorkflowDevImage),
-		mountDevConfigMapsMutateVisitor(flowDefCM.(*v1.ConfigMap), propsCM.(*v1.ConfigMap)))
+		mountDevConfigMapsMutateVisitor(flowDefCM.(*v1.ConfigMap), propsCM.(*v1.ConfigMap)),
+		disableKnativeEventingHealthCheckMutateVisitor())
 	if err != nil {
 		return ctrl.Result{RequeueAfter: requeueAfterFailure}, objs, err
 	}
@@ -328,6 +329,20 @@ func rolloutDeploymentIfCMChangedMutateVisitor(cmOperationResult controllerutil.
 				err := kubeutil.MarkDeploymentToRollout(deployment)
 				return err
 			}
+			return nil
+		}
+	}
+}
+
+// disableKnativeEventingHealthCheckMutateVisitor injects the EnvVar to disable the Knative Eventing Addon Health Check
+//
+// See: https://kiegroup.github.io/kogito-docs/serverlessworkflow/latest/eventing/consume-produce-events-with-knative-eventing.html#ref-knative-eventing-add-on-source-configuration
+// TODO: once we implement (https://issues.redhat.com/browse/KOGITO-8649), we should be able to manage a few configuration properties in the managed CM. This property should be there.
+func disableKnativeEventingHealthCheckMutateVisitor() mutateVisitor {
+	return func(object client.Object) controllerutil.MutateFn {
+		return func() error {
+			deployment := object.(*appsv1.Deployment)
+			kubeutil.CreateOrReplaceEnv(&deployment.Spec.Template.Spec.Containers[0], "ORG_KIE_KOGITO_ADDONS_KNATIVE_HEALTH_ENABLED", "false")
 			return nil
 		}
 	}

--- a/controllers/profiles/reconciler_dev_test.go
+++ b/controllers/profiles/reconciler_dev_test.go
@@ -86,6 +86,9 @@ func Test_newDevProfile(t *testing.T) {
 	// check if the objects have been created
 	deployment := test.MustGetDeployment(t, client, workflow)
 	assert.Equal(t, defaultKogitoServerlessWorkflowDevImage, deployment.Spec.Template.Spec.Containers[0].Image)
+	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe)
+	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
+	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].StartupProbe)
 
 	defCM := test.MustGetConfigMap(t, client, workflow)
 	assert.NotEmpty(t, defCM.Data[workflow.Name+kogitoWorkflowJSONFileExt])

--- a/utils/kubernetes/env.go
+++ b/utils/kubernetes/env.go
@@ -1,0 +1,33 @@
+// Copyright 2023 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import v1 "k8s.io/api/core/v1"
+
+func CreateOrReplaceEnv(container *v1.Container, name, value string) {
+	found := false
+	for i := range container.Env {
+		if container.Env[i].Name == name {
+			container.Env[i].Value = value
+			found = true
+		}
+	}
+	if !found {
+		container.Env = append(container.Env, v1.EnvVar{
+			Name:  name,
+			Value: value,
+		})
+	}
+}

--- a/utils/kubernetes/env_test.go
+++ b/utils/kubernetes/env_test.go
@@ -1,0 +1,53 @@
+// Copyright 2023 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestCreateOrReplaceEnv(t *testing.T) {
+	containerNoEnv := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{Env: nil}},
+				},
+			},
+		},
+	}
+	containerWithEnv := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{Env: []v1.EnvVar{{
+						Name:  "myvar",
+						Value: "myvalue",
+					}}}},
+				},
+			},
+		},
+	}
+
+	CreateOrReplaceEnv(&containerNoEnv.Spec.Template.Spec.Containers[0], "myvar", "mutated")
+	assert.Equal(t, "mutated", containerNoEnv.Spec.Template.Spec.Containers[0].Env[0].Value)
+
+	CreateOrReplaceEnv(&containerWithEnv.Spec.Template.Spec.Containers[0], "myvar", "mutated")
+	assert.Equal(t, "mutated", containerWithEnv.Spec.Template.Spec.Containers[0].Env[0].Value)
+}


### PR DESCRIPTION
**Description of the change:**

Adding the health checks to the default deployment. It requires a change in the builder image to include the health check addon. We might also have to disable the Knative health check in dev profile.

Depends on:

- https://github.com/kiegroup/kogito-images/pull/1444

**Motivation for the change:**

See: https://issues.redhat.com/browse/KOGITO-8642

**Checklist**

- [x] Modify the builder image to include health checks
- [x] Verify if the Knative Eventing health check can be disabled in the dev profile
- [x] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>