### PR TITLE
[Kogito-9207] [Operator] Make QUARKUS_KOGITO_DEVSERVICES_ENABLED and QUARKUS_DEVSERVICES_ENABLED properties immutable in devmode

### DIFF
--- a/controllers/profiles/object_creators.go
+++ b/controllers/profiles/object_creators.go
@@ -31,9 +31,11 @@ import (
 )
 
 const (
-	defaultHTTPWorkflowPort = 8080
-	defaultHTTPServicePort  = 80
-	defaultContainerName    = "workflow"
+	defaultHTTPWorkflowPortInt = 8080
+	defaultHTTPWorkflowPortStr = "8080"
+	defaultContainerName       = "workflow"
+
+	defaultHTTPServicePort = 80
 
 	applicationPropertiesFileName = "application.properties"
 
@@ -55,6 +57,8 @@ const (
 	healthStartedPeriodSeconds       = 15
 	healthStartedInitialDelaySeconds = 10
 )
+
+var defaultHTTPWorkflowPortIntStr = intstr.FromInt(defaultHTTPWorkflowPortInt)
 
 // same for now
 var defaultProdApplicationProperties = defaultDevApplicationProperties
@@ -87,14 +91,14 @@ func defaultDeploymentCreator(workflow *operatorapi.KogitoServerlessWorkflow) (c
 					Containers: []corev1.Container{{
 						Name: defaultContainerName,
 						Ports: []corev1.ContainerPort{{
-							ContainerPort: defaultHTTPWorkflowPort,
+							ContainerPort: defaultHTTPWorkflowPortInt,
 							Name:          "http",
 						}},
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{
 									Path: quarkusHealthPathLive,
-									Port: intstr.FromInt(defaultHTTPWorkflowPort),
+									Port: defaultHTTPWorkflowPortIntStr,
 								},
 							},
 							TimeoutSeconds: healthTimeoutSeconds,
@@ -103,7 +107,7 @@ func defaultDeploymentCreator(workflow *operatorapi.KogitoServerlessWorkflow) (c
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{
 									Path: quarkusHealthPathReady,
-									Port: intstr.FromInt(defaultHTTPWorkflowPort),
+									Port: defaultHTTPWorkflowPortIntStr,
 								},
 							},
 							TimeoutSeconds: healthTimeoutSeconds,
@@ -112,7 +116,7 @@ func defaultDeploymentCreator(workflow *operatorapi.KogitoServerlessWorkflow) (c
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{
 									Path: quarkusHealthPathStarted,
-									Port: intstr.FromInt(defaultHTTPWorkflowPort),
+									Port: defaultHTTPWorkflowPortIntStr,
 								},
 							},
 							InitialDelaySeconds: healthStartedInitialDelaySeconds,
@@ -178,7 +182,7 @@ func defaultServiceCreator(workflow *operatorapi.KogitoServerlessWorkflow) (clie
 			Ports: []corev1.ServicePort{{
 				Protocol:   corev1.ProtocolTCP,
 				Port:       defaultHTTPServicePort,
-				TargetPort: intstr.FromInt(defaultHTTPWorkflowPort),
+				TargetPort: defaultHTTPWorkflowPortIntStr,
 			}},
 		},
 	}

--- a/controllers/profiles/object_creators_dev.go
+++ b/controllers/profiles/object_creators_dev.go
@@ -15,8 +15,6 @@
 package profiles
 
 import (
-	"strconv"
-
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -27,11 +25,13 @@ import (
 	operatorapi "github.com/kiegroup/kogito-serverless-operator/api/v1alpha08"
 )
 
-var defaultDevApplicationProperties = "quarkus.http.port=" + strconv.Itoa(defaultHTTPWorkflowPort) + "\n" +
+var defaultDevApplicationProperties = "quarkus.http.port=" + defaultHTTPWorkflowPortStr + "\n" +
 	"quarkus.http.host=0.0.0.0\n" +
 	// We disable the Knative health checks to not block the dev pod to run if Knative objects are not available
 	// See: https://kiegroup.github.io/kogito-docs/serverlessworkflow/latest/eventing/consume-produce-events-with-knative-eventing.html#ref-knative-eventing-add-on-source-configuration
-	"org.kie.kogito.addons.knative.eventing.health-enabled=false\n"
+	"org.kie.kogito.addons.knative.eventing.health-enabled=false\n" +
+	"quarkus.devservices.enabled=false=false\n" +
+	"quarkus.kogito.devservices.enabled=false=false\n"
 
 // devServiceCreator is an objectCreator for a basic Service for a workflow using dev profile
 // aiming a vanilla Kubernetes Deployment.

--- a/controllers/profiles/reconciler_dev_test.go
+++ b/controllers/profiles/reconciler_dev_test.go
@@ -118,7 +118,7 @@ func Test_newDevProfile(t *testing.T) {
 	assert.Contains(t, propCM.Data[applicationPropertiesFileName], "quarkus.http.port")
 
 	service := test.MustGetService(t, client, workflow)
-	assert.Equal(t, int32(defaultHTTPWorkflowPort), service.Spec.Ports[0].TargetPort.IntVal)
+	assert.Equal(t, int32(defaultHTTPWorkflowPortInt), service.Spec.Ports[0].TargetPort.IntVal)
 
 	workflow.Status.Manager().MarkTrue(api.RunningConditionType)
 	err = client.Status().Update(context.TODO(), workflow)
@@ -136,7 +136,7 @@ func Test_newDevProfile(t *testing.T) {
 
 	// check if the reconciliation ensures the object correctly
 	service = test.MustGetService(t, client, workflow)
-	assert.Equal(t, int32(defaultHTTPWorkflowPort), service.Spec.Ports[0].TargetPort.IntVal)
+	assert.Equal(t, int32(defaultHTTPWorkflowPortInt), service.Spec.Ports[0].TargetPort.IntVal)
 
 	// now with the deployment
 	deployment = test.MustGetDeployment(t, client, workflow)


### PR DESCRIPTION
See:https://issues.redhat.com/browse/KOGITO-9207

<!--

Welcome to the Kogito Serverless Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>