### PR TITLE
[KOGITO-9262] extend devmode probes threshold

### DIFF
--- a/controllers/profiles/reconciler_dev.go
+++ b/controllers/profiles/reconciler_dev.go
@@ -104,7 +104,7 @@ func newDevProfileReconciler(client client.Client, config *rest.Config, logger *
 
 func newDevelopmentObjectEnsurers(support *stateSupport) *devProfileObjectEnsurers {
 	return &devProfileObjectEnsurers{
-		deployment:          newDefaultObjectEnsurer(support.client, support.logger, defaultDeploymentCreator),
+		deployment:          newDefaultObjectEnsurer(support.client, support.logger, devDeploymentCreator),
 		service:             newDefaultObjectEnsurer(support.client, support.logger, devServiceCreator),
 		network:             newDummyObjectEnsurer(),
 		definitionConfigMap: newDefaultObjectEnsurer(support.client, support.logger, workflowDefConfigMapCreator),
@@ -114,7 +114,7 @@ func newDevelopmentObjectEnsurers(support *stateSupport) *devProfileObjectEnsure
 
 func newDevelopmentObjectEnsurersForOpenShift(support *stateSupport) *devProfileObjectEnsurers {
 	return &devProfileObjectEnsurers{
-		deployment:          newDefaultObjectEnsurer(support.client, support.logger, defaultDeploymentCreator),
+		deployment:          newDefaultObjectEnsurer(support.client, support.logger, devDeploymentCreator),
 		service:             newDefaultObjectEnsurer(support.client, support.logger, defaultServiceCreator),
 		network:             newDefaultObjectEnsurer(support.client, support.logger, defaultNetworkCreator),
 		definitionConfigMap: newDefaultObjectEnsurer(support.client, support.logger, workflowDefConfigMapCreator),


### PR DESCRIPTION
<!--

Welcome to the Kogito Serverless Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
Small change to enhance devmode experience: https://issues.redhat.com/browse/KOGITO-9262

**Motivation for the change:**


**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>