### PR TITLE
add hack/get-images-sha.sh script

### DIFF
--- a/hack/get-images-sha.sh
+++ b/hack/get-images-sha.sh
@@ -15,7 +15,7 @@
 
 #
 # This script fetches the sha256 of images built on Brew and tagged into a specific Brew tag.
-# As an input it required the OpenShift Serverless Logic produt version.
+# As an input it requires the OpenShift Serverless Logic produt version.
 #
 # Example to run:
 # $ ./get-images-sha.sh 1.29
@@ -24,6 +24,12 @@
 #
 
 imagesBrewPackageName=("openshift-serverless-1-logic-rhel8-operator-container")
+
+if ! command -v brew > /dev/null;
+then
+    echo "brew command not available in the system, please install brewkoji package"
+    exit 1
+fi
 
 if [ $# -eq 0 ];
 then

--- a/hack/get-images-sha.sh
+++ b/hack/get-images-sha.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2023 Red Hat, Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This script fetches the sha256 of images built on Brew and tagged into a specific Brew tag.
+# As an input it required the OpenShift Serverless Logic produt version.
+#
+# Example to run:
+# $ ./get-images-sha.sh 1.29
+#
+# Note: brewkoji package is required.
+#
+
+imagesBrewPackageName=("openshift-serverless-1-logic-rhel8-operator-container")
+
+if [ $# -eq 0 ];
+then
+    echo "$0: Missing the OpenShift Serverless Logic version input"
+    exit 1
+fi
+
+oslVersion=$1
+brewTag="openshift-serverless-${oslVersion}-rhel-8-container-candidate"
+for brewPackageName in ${imagesBrewPackageName[@]}; do
+    echo "Finding latest Brew build for package ${brewPackageName}"
+    brewBuild=$(brew latest-build ${brewTag} ${brewPackageName} | tail -n1 | cut -d ' ' -f1)
+    echo "Found Brew build: ${brewBuild}"
+    imageSha=$(brew buildinfo "${brewBuild}" | awk -F'Extra: ' '{print $2}' | tr \' \" | sed 's|False|\"false\"|g' | sed 's|True|\"true\"|g' | sed 's|None|\"\"|g' | jq -r '.image.index.pull[0]'| cut -d "@" -f2)
+    echo "Image sha: ${imageSha}"
+    echo "---"
+done


### PR DESCRIPTION
This script allows to fetch the sha256 of any image built in Brew. Currently it is fetching just the Operator as the sha256 of the Operator is required when building the Bundle.

<!--

Welcome to the Kogito Serverless Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>