### PR TITLE
[KOGITO-9290] Removing Owner references from generated objects

### DIFF
--- a/workflowproj/workflowproj.go
+++ b/workflowproj/workflowproj.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/kiegroup/kogito-serverless-operator/api/metadata"
+	operatorapi "github.com/kiegroup/kogito-serverless-operator/api/v1alpha08"
 	"github.com/pkg/errors"
 	"github.com/serverlessworkflow/sdk-go/v2/model"
 	"github.com/serverlessworkflow/sdk-go/v2/parser"
@@ -26,10 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	"github.com/kiegroup/kogito-serverless-operator/api/metadata"
-	operatorapi "github.com/kiegroup/kogito-serverless-operator/api/v1alpha08"
 )
 
 var _ WorkflowProjectHandler = &workflowProjectHandler{}
@@ -244,7 +242,7 @@ func (w *workflowProjectHandler) parseRawAppProperties() error {
 	if err = SetTypeToObject(w.project.Properties, w.scheme); err != nil {
 		return err
 	}
-	return controllerutil.SetOwnerReference(w.project.Workflow, w.project.Properties, w.scheme)
+	return nil
 }
 
 func (w *workflowProjectHandler) parseRawResources() error {
@@ -290,9 +288,6 @@ func (w *workflowProjectHandler) parseRawResources() error {
 func (w *workflowProjectHandler) addExternalResConfigMapToProject(cms ...*corev1.ConfigMap) error {
 	for _, cm := range cms {
 		if cm.Data != nil {
-			if err := controllerutil.SetOwnerReference(w.project.Workflow, cm, w.scheme); err != nil {
-				return err
-			}
 			if err := SetTypeToObject(cm, w.scheme); err != nil {
 				return err
 			}

--- a/workflowproj/workflowproj.go
+++ b/workflowproj/workflowproj.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/kiegroup/kogito-serverless-operator/api/metadata"
-	operatorapi "github.com/kiegroup/kogito-serverless-operator/api/v1alpha08"
 	"github.com/pkg/errors"
 	"github.com/serverlessworkflow/sdk-go/v2/model"
 	"github.com/serverlessworkflow/sdk-go/v2/parser"
@@ -28,6 +26,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/kiegroup/kogito-serverless-operator/api/metadata"
+	operatorapi "github.com/kiegroup/kogito-serverless-operator/api/v1alpha08"
 )
 
 var _ WorkflowProjectHandler = &workflowProjectHandler{}


### PR DESCRIPTION
**Description of the change:**
In this PR we removed the owner references to the child objects because we can only perform this operating having the owner object ID. Since the workflow is not created yet, we can't possibly know. During the first reconciliation, thou, the operator will add this reference to the properties `configMap`, which is enough. The other generated CMs shouldn't have this reference since we won't reconcile or own them.

**Motivation for the change:**
See: https://issues.redhat.com/browse/KOGITO-9290

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>