### PR TITLE
Fixing workflowproj module importing latest Operator apis

### DIFF
--- a/workflowproj/go.mod
+++ b/workflowproj/go.mod
@@ -2,11 +2,8 @@ module github.com/kiegroup/kogito-serverless-operator/workflowproj
 
 go 1.19
 
-// Internal dependencies
-replace github.com/kiegroup/kogito-serverless-operator/api v0.0.0 => ../api
-
 require (
-	github.com/kiegroup/kogito-serverless-operator/api v0.0.0
+	github.com/kiegroup/kogito-serverless-operator/api v0.0.0-20230612141803-7bb1dd4abd50
 	github.com/pb33f/libopenapi v0.8.4
 	github.com/pkg/errors v0.9.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0

--- a/workflowproj/go.sum
+++ b/workflowproj/go.sum
@@ -87,6 +87,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kiegroup/kogito-serverless-operator/api v0.0.0-20230612141803-7bb1dd4abd50 h1:lNLiJzquP7Yasi2EDM6g7TD/R6Wkem0YcPcwfz8cIB4=
+github.com/kiegroup/kogito-serverless-operator/api v0.0.0-20230612141803-7bb1dd4abd50/go.mod h1:qqIVVrGPAyFmpHAsRaKLVy9pe5VIqRa11YvvcfA94TI=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
<!--

Welcome to the Kogito Serverless Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**

With this fix, everyone will be able to use the `workflowproj` go module outside the Kogito Servereless Workflow Operator

**Motivation for the change:**

We cannot use the `workflowproj` go module outside the Kogito Servereless Workflow Operator, due to the fact that we are using a `replace` directive into the `go.mod` and at the same time the `api` go module is without version.

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>