### PR TITLE
[KOGITO-9313] Selectively change Deployment to avoid multiple pods/re…

### DIFF
--- a/controllers/profiles/object_creators_dev.go
+++ b/controllers/profiles/object_creators_dev.go
@@ -78,12 +78,7 @@ func devDeploymentMutateVisitor(workflow *operatorapi.KogitoServerlessWorkflow) 
 			if err != nil {
 				return err
 			}
-			object.(*appsv1.Deployment).Spec.Template.Spec.Volumes = make([]corev1.Volume, 0)
-			object.(*appsv1.Deployment).Spec.Template.Spec.Volumes = original.(*appsv1.Deployment).Spec.Template.Spec.Volumes
-			object.(*appsv1.Deployment).Spec.Template.Spec.Containers = make([]corev1.Container, 0)
-			object.(*appsv1.Deployment).Spec.Template.Spec.Containers = original.(*appsv1.Deployment).Spec.Template.Spec.Containers
-			object.(*appsv1.Deployment).Spec.Replicas = original.(*appsv1.Deployment).Spec.Replicas
-			object.(*appsv1.Deployment).Labels = original.GetLabels()
+			ensureDefaultDeployment(original.(*appsv1.Deployment), object.(*appsv1.Deployment))
 			return nil
 		}
 	}

--- a/utils/kubernetes/deployment.go
+++ b/utils/kubernetes/deployment.go
@@ -82,3 +82,17 @@ func MarkDeploymentToRollout(deployment *appsv1.Deployment) error {
 	deployment.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 	return nil
 }
+
+// GetContainerByName returns a pointer to the Container within the given Deployment.
+// If none found, returns nil.
+func GetContainerByName(name string, deployment *appsv1.Deployment) *v1.Container {
+	if deployment == nil {
+		return nil
+	}
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == name {
+			return &container
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
…conciliation cycles

<!--

Welcome to the Kogito Serverless Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

See: https://issues.redhat.com/browse/KOGITO-9313

**Description of the change:**
In this PR, we do a small change to the ensurer to avoid reconciliation loops and creation of more than one pod when they are semantically equal.

**Motivation for the change:**
To avoid multiple pods creation due to `DeepEqual` comparisons in the controllerutil.


**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>