### PR TITLE
[KOGITO-9348][OPERATOR-KSW] API version not updated in workflowproj module

### DIFF
--- a/workflowproj/go.mod
+++ b/workflowproj/go.mod
@@ -3,7 +3,6 @@ module github.com/kiegroup/kogito-serverless-operator/workflowproj
 go 1.19
 
 require (
-	github.com/kiegroup/kogito-serverless-operator/api v0.0.0-20230612141803-7bb1dd4abd50
 	github.com/pb33f/libopenapi v0.8.4
 	github.com/pkg/errors v0.9.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
@@ -41,6 +40,7 @@ require (
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kiegroup/kogito-serverless-operator/api v0.0.0-20230613074518-8c40a054ef3c // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect

--- a/workflowproj/go.sum
+++ b/workflowproj/go.sum
@@ -95,6 +95,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kiegroup/kogito-serverless-operator/api v0.0.0-20230612141803-7bb1dd4abd50 h1:lNLiJzquP7Yasi2EDM6g7TD/R6Wkem0YcPcwfz8cIB4=
 github.com/kiegroup/kogito-serverless-operator/api v0.0.0-20230612141803-7bb1dd4abd50/go.mod h1:qqIVVrGPAyFmpHAsRaKLVy9pe5VIqRa11YvvcfA94TI=
+github.com/kiegroup/kogito-serverless-operator/api v0.0.0-20230613074518-8c40a054ef3c h1:NnuKFXj+IBNS6Mo1u7FIZwt+Q6q5lCiLlwgwAvNn+us=
+github.com/kiegroup/kogito-serverless-operator/api v0.0.0-20230613074518-8c40a054ef3c/go.mod h1:W6mlmZuoa+yDwSRXiUEpNif0LBwzRAbpk0Xa4nxCOO0=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
See:https://issues.redhat.com/browse/KOGITO-9348
<!--

Welcome to the Kogito Serverless Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.


Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>