### PR TITLE
[KOGITO-9244]  Platform.spec.platform.baseImage does not update the Dockerfile base image

### DIFF
--- a/bundle/manifests/sonataflow-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sonataflow-operator.clusterserviceversion.yaml
@@ -101,7 +101,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/kiegroup/kogito-serverless-operator
     support: Red Hat
-  name: sonataflow-operator.vlatest
+  name: sonataflow-operator.v2.0.0-snapshot
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -446,7 +446,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kiegroup/kogito-serverless-operator-nightly:latest
+                image: quay.io/kiegroup/kogito-serverless-operator-nightly:2.0.0-snapshot
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -537,4 +537,4 @@ spec:
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat
-  version: latest
+  version: 2.0.0-snapshot

--- a/bundle/manifests/sonataflow-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sonataflow-operator.clusterserviceversion.yaml
@@ -101,7 +101,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/kiegroup/kogito-serverless-operator
     support: Red Hat
-  name: sonataflow-operator.v2.0.0-snapshot
+  name: sonataflow-operator.vlatest
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -446,7 +446,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kiegroup/kogito-serverless-operator-nightly:2.0.0-snapshot
+                image: quay.io/kiegroup/kogito-serverless-operator-nightly:latest
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -537,4 +537,4 @@ spec:
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat
-  version: 2.0.0-snapshot
+  version: latest

--- a/controllers/builder/containerbuilder.go
+++ b/controllers/builder/containerbuilder.go
@@ -96,7 +96,7 @@ func newContainerBuilderManager(managerContext buildManagerContext, config *rest
 }
 
 func (c *containerBuilderManager) getImageBuilderForKaniko(workflowID string, imageNameTag string, workflowDefinition []byte, task *api.KanikoTask) imageBuilder {
-	containerFile := c.commonConfig.Data[c.commonConfig.Data[configKeyDefaultBuilderResourceName]]
+	containerFile := platform.GetCustomizedDockerfile(c.commonConfig.Data[c.commonConfig.Data[configKeyDefaultBuilderResourceName]], *c.platform)
 	ib := NewImageBuilder(workflowID, workflowDefinition, []byte(containerFile))
 	ib.OnNamespace(c.platform.Namespace)
 	ib.WithPodMiddleName(workflowID)

--- a/controllers/builder/openshiftbuilder.go
+++ b/controllers/builder/openshiftbuilder.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/kiegroup/kogito-serverless-operator/controllers/platform"
 	"github.com/kiegroup/kogito-serverless-operator/workflowproj"
 
 	kubeutil "github.com/kiegroup/kogito-serverless-operator/utils/kubernetes"
@@ -143,7 +144,7 @@ func (o *openshiftBuilderManager) Schedule(build *operatorapi.SonataFlowBuild) e
 
 func (o *openshiftBuilderManager) newDefaultBuildConfig(build *operatorapi.SonataFlowBuild) *buildv1.BuildConfig {
 	optimizationPol := buildv1.ImageOptimizationSkipLayers
-	dockerFile := o.commonConfig.Data[o.commonConfig.Data[configKeyDefaultBuilderResourceName]]
+	dockerFile := platform.GetCustomizedDockerfile(o.commonConfig.Data[o.commonConfig.Data[configKeyDefaultBuilderResourceName]], *o.platform)
 	return &buildv1.BuildConfig{
 		ObjectMeta: metav1.ObjectMeta{Namespace: build.Namespace, Name: build.Name},
 		Spec: buildv1.BuildConfigSpec{

--- a/controllers/platform/platformutils_test.go
+++ b/controllers/platform/platformutils_test.go
@@ -1,0 +1,46 @@
+// Copyright 2023 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kiegroup/kogito-serverless-operator/test"
+)
+
+func TestSonataFlowBuildController(t *testing.T) {
+	platform := test.GetBasePlatform()
+	dockerfileBytes, err := os.ReadFile("../../test/builder/Dockerfile")
+	if err != nil {
+		assert.Fail(t, "Unable to read base Dockerfile")
+	}
+	dockerfile := string(dockerfileBytes)
+	// 1 - Let's verify that the default image is used (for this unit test is quay.io/kiegroup/kogito-swf-builder-nightly:latest)
+	resDefault := GetCustomizedDockerfile(dockerfile, *platform)
+	foundDefault, err := regexp.MatchString("FROM quay.io/kiegroup/kogito-swf-builder-nightly:latest AS builder", resDefault)
+	assert.NoError(t, err)
+	assert.True(t, foundDefault)
+
+	// 2 - Let's try to override using the productized image
+	platform.Spec.BuildPlatform.BaseImage = "registry.access.redhat.com/openshift-serverless-1-tech-preview/logic-swf-builder-rhel8"
+	resProductized := GetCustomizedDockerfile(dockerfile, *platform)
+	foundProductized, err := regexp.MatchString("FROM registry.access.redhat.com/openshift-serverless-1-tech-preview/logic-swf-builder-rhel8 AS builder", resProductized)
+	assert.NoError(t, err)
+	assert.True(t, foundProductized)
+}

--- a/test/yaml.go
+++ b/test/yaml.go
@@ -39,6 +39,8 @@ const (
 	sonataFlowPlatformForOpenshift            = "sonataflow.org_v1alpha08_sonataflowplatform_openshift.yaml"
 	sonataFlowBuilderConfig                   = "sonataflow-operator-builder-config_v1_configmap.yaml"
 
+	BuilderDockerfile = "builder_dockerfile.yaml"
+
 	configSamplesOneLevelPath = "../config/samples/"
 	configSamplesTwoLevelPath = "../../config/samples/"
 	e2eSamples                = "test/testdata/"


### PR DESCRIPTION
**Description of the change:**

I added a the `GetCustomizedDockerfile`  func that will let us replace the base builder image used into the Dockerfile the Operator has got into the common builder ConfigMap with the `platform.spec.platform.baseImage` (only if present).

**Motivation for the change:**

See [KOGITO-9244](https://issues.redhat.com/browse/KOGITO-9244)

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>