### PR TITLE
Add Supporting to OpenShift 4.11 and later to the bundle

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -8,6 +8,7 @@ annotations:
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+  com.redhat.openshift.versions: v4.11
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1


### PR DESCRIPTION
Small change to the manifests to support only OCP 4.11 and later.