### PR TITLE
KOGITO-9560 Use `latest` version in CSV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.41.0-snapshot
-REDUCED_VERSION ?= 1.41
+VERSION ?= 2.0.0-snapshot
+REDUCED_VERSION ?= latest
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 2.0.0-snapshot
+VERSION ?= 1.41.0-snapshot
+REDUCED_VERSION ?= 1.41
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -33,7 +34,7 @@ IMAGE_TAG_BASE ?= quay.io/kiegroup/kogito-serverless-operator-nightly
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
+BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(REDUCED_VERSION)
 
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 # TODO: review this flag once we upgrade https://github.com/operator-framework/operator-sdk/issues/4992 (https://issues.redhat.com/browse/KOGITO-9428)
@@ -52,7 +53,7 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
+IMG ?= $(IMAGE_TAG_BASE):$(REDUCED_VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24
 

--- a/bundle/manifests/sonataflow-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sonataflow-operator.clusterserviceversion.yaml
@@ -446,7 +446,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kiegroup/kogito-serverless-operator-nightly:2.0.0-snapshot
+                image: quay.io/kiegroup/kogito-serverless-operator-nightly:latest
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -20,7 +20,7 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kiegroup/kogito-serverless-operator-nightly
-  newTag: 2.0.0-snapshot
+  newTag: latest
 # Patching the manager deployment file to add an env var with the operator namespace in
 patchesJson6902:
 - patch: |-

--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -44,6 +44,7 @@ echo "Set new version to ${new_version} (img_suffix = '${imageSuffix}', majorMin
 sed -i "s|version: ${old_version}|version: ${new_version}|g" image.yaml
 
 sed -i "s|^VERSION ?=.*|VERSION ?= ${new_version}|g" Makefile
+sed -i "s|^REDUCED_VERSION ?=.*|REDUCED_VERSION ?= ${newMajorMinorVersion}|g" Makefile
 sed -i "s|newTag:.*|newTag: ${new_version}|g" config/manager/kustomization.yaml
 
 sed -i "s|IMAGE_TAG_BASE ?=.*|IMAGE_TAG_BASE ?= ${imageTag}${imageSuffix}|g" Makefile
@@ -60,8 +61,5 @@ sed -i -r "s|OperatorVersion =.*|OperatorVersion = \"${new_version}\"|g" version
 
 make generate-all
 make vet
-
-# Update bundle
-sed -i "s|${new_version}|${newMajorMinorVersion}|g" $(getBundleFile)
 
 echo "Version bumped to ${new_version}"

--- a/operator.yaml
+++ b/operator.yaml
@@ -3175,7 +3175,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kiegroup/kogito-serverless-operator-nightly:2.0.0-snapshot
+        image: quay.io/kiegroup/kogito-serverless-operator-nightly:latest
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-9560

Result for a release branch: https://github.com/kiegroup/kogito-serverless-operator/commit/e3723e901688251b9bc345f331f77f5183d2cf1f

Result for the main branch can be found in this PR