### PR TITLE
order-processing event-listener E2E test is not runnable on the arm64…

### DIFF
--- a/test/testdata/order-processing/02_appsv1_deployment_eventlistener.yaml
+++ b/test/testdata/order-processing/02_appsv1_deployment_eventlistener.yaml
@@ -52,6 +52,6 @@ spec:
                 - ALL
             seccompProfile:
               type: "RuntimeDefault"
-          image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display:latest
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/event_display:latest
           ports:
             - containerPort: 8080


### PR DESCRIPTION
**JIRA:** [KOGITO-9655](https://issues.redhat.com/browse/KOGITO-9655)

**Description of the change:**
We found with @radtriste that the arm64 image is not available from the eventing-contrib image as it has been unmaintained since 2020. We need to change the image to the eventing one which is regularly updated.

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>