### PR TITLE
[KOGITO-9653] - Fix how to handle WaitingForDeployment condition to avoid pod duplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/controllers/profiles/reconciler_dev.go
+++ b/controllers/profiles/reconciler_dev.go
@@ -264,7 +264,7 @@ func (f *followDeployDevWorkflowReconciliationState) Do(ctx context.Context, wor
 		return ctrl.Result{RequeueAfter: requeueAfterIsRunning}, nil, nil
 	}
 
-	if kubeutil.IsDeploymentProgressing(deployment) {
+	if !kubeutil.IsDeploymentFailed(deployment) {
 		workflow.Status.Manager().MarkFalse(api.RunningConditionType, api.WaitingForDeploymentReason, "")
 		f.logger.Info("Workflow is in WaitingForDeployment Condition")
 		if _, err := f.performStatusUpdate(ctx, workflow); err != nil {

--- a/utils/kubernetes/deployment.go
+++ b/utils/kubernetes/deployment.go
@@ -34,21 +34,18 @@ func IsDeploymentAvailable(deployment *appsv1.Deployment) bool {
 	return false
 }
 
-// IsDeploymentProgressing checks if the Deployment is progressing/scaling its replicas.
-// Not progressing doesn't necessarily mean that the deployment is in a failure state.
-// It might be running under the required replicas, always check IsDeploymentAvailable and GetDeploymentUnavailabilityMessage to understand the real condition.
-func IsDeploymentProgressing(deployment *appsv1.Deployment) bool {
-	if !IsDeploymentAvailable(deployment) {
-		// it's not available, so let's check if it's progressing
-		for _, condition := range deployment.Status.Conditions {
-			if condition.Type == appsv1.DeploymentProgressing &&
-				condition.Status == v1.ConditionTrue {
-				return true
-			}
+// IsDeploymentFailed returns true in case of Deployment not available (IsDeploymentAvailable returns false) or it has a condition of
+// DeploymentReplicaFailure == true.
+func IsDeploymentFailed(deployment *appsv1.Deployment) bool {
+	if IsDeploymentAvailable(deployment) {
+		return false
+	}
+	for _, condition := range deployment.Status.Conditions {
+		if condition.Type == appsv1.DeploymentReplicaFailure &&
+			condition.Status == v1.ConditionTrue {
+			return true
 		}
 	}
-
-	// it might be either a failure or it's available
 	return false
 }
 


### PR DESCRIPTION
**Description of the change:**
We used to handle deployment progress wrongly, hence spamming unneeded deployment rollouts. After this change, our handlers will wait until a failure before doing a rollout.

**Motivation for the change:**
See: https://issues.redhat.com/browse/KOGITO-9653

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>