### PR TITLE
KOGITO-5386: added a new parameter for unique branch name

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -83,6 +83,9 @@ pipeline {
             }
             steps {
                 script {
+                    if (githubscm.isBranchExist('origin', helper.getPRBranch())) {
+                        githubscm.removeRemoteBranch('origin', helper.getPRBranch())
+                    }
                     githubscm.createBranch(helper.getPRBranch())
                 }
             }

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -100,6 +100,7 @@ void setupDeployJob(JobType jobType) {
             stringParam('IMAGE_NAMESPACE', "${CLOUD_IMAGE_NAMESPACE}", 'Image namespace to use to deploy images')
             stringParam('IMAGE_NAME_SUFFIX', '', 'Image name suffix to use to deploy images. In case you need to change the final image name, you can add a suffix to it.')
             stringParam('IMAGE_TAG', '', 'Image tag to use to deploy images')
+            stringParam('KOGITO_PR_BRANCH', '', 'PR branch name')
             booleanParam('DEPLOY_WITH_LATEST_TAG', false, 'Set to true if you want the deployed image to also be with the `latest` tag')
 
             booleanParam('SEND_NOTIFICATION', false, 'In case you want the pipeline to send a notification on CI channel for this run.')

--- a/.ci/jenkins/scripts/helper.groovy
+++ b/.ci/jenkins/scripts/helper.groovy
@@ -256,7 +256,7 @@ String getGitAuthorCredsID() {
 }
 
 String getPRBranch() {
-    return "${getProjectVersion()}-${env.PR_BRANCH_HASH}"
+    return params.KOGITO_PR_BRANCH
 }
 
 String getProjectVersion() {


### PR DESCRIPTION
JIRA: [5386](https://issues.redhat.com/browse/KOGITO-5386)

related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/1024
- https://github.com/kiegroup/kogito-runtimes/pull/3161
- https://github.com/kiegroup/kogito-apps/pull/1820
- https://github.com/kiegroup/kogito-examples/pull/1757
- https://github.com/kiegroup/kogito-images/pull/1666
- https://github.com/kiegroup/kogito-operator/pull/1504
- https://github.com/kiegroup/kogito-serverless-operator/pull/218

<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
The branch name during a release will be the same for all repositories deployed

**Motivation for the change:**


**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>