### PR TITLE
KOGITO-9692 Fix release generation

### DIFF
--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -125,7 +125,7 @@ pipeline {
                     if(githubscm.isReleaseExist(helper.getGitTag(), helper.getGitAuthorCredsID())) {
                         githubscm.deleteReleaseAndTag(helper.getGitTag(), helper.getGitAuthorCredsID())
                     }
-                    githubscm.createReleaseWithGeneratedReleaseNotes(helper.getGitTag(), helper.getBuildBranch(), githubscm.getPreviousTag(helper.getGitTag()), helper.getGitAuthorCredsID())
+                    githubscm.createReleaseWithGeneratedReleaseNotes(helper.getGitTag(), helper.getBuildBranch(), githubscm.getPreviousTagFromVersion(helper.getGitTag(), 'v', '', ['/']), helper.getGitAuthorCredsID())
                     githubscm.updateReleaseBody(helper.getGitTag(), helper.getGitAuthorCredsID())
 
                     withCredentials([usernamePassword(credentialsId: helper.getGitAuthorCredsID(), usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {


### PR DESCRIPTION
Depends on https://issues.redhat.com/browse/KOGITO-9692

Related:
- https://github.com/kiegroup/kogito-runtimes/pull/3170
- https://github.com/kiegroup/kogito-apps/pull/1826
- https://github.com/kiegroup/kogito-examples/pull/1761
- https://github.com/kiegroup/kogito-images/pull/1670
- https://github.com/kiegroup/kogito-operator/pull/1511
- https://github.com/kiegroup/kogito-serverless-operator/pull/225