### PR TITLE
fix: issues with kaniko build

### DIFF
--- a/container-builder/builder/kubernetes/kaniko.go
+++ b/container-builder/builder/kubernetes/kaniko.go
@@ -78,6 +78,7 @@ func addKanikoTaskToPod(ctx context.Context, c client.Client, build *api.Contain
 		"--dockerfile=Dockerfile",
 		"--context=dir://" + task.ContextDir,
 		"--destination=" + task.GetRepositoryImageTag(),
+		"--ignore-path=/product_uuid",
 	}
 
 	if task.AdditionalFlags != nil && len(task.AdditionalFlags) > 0 {


### PR DESCRIPTION
When using multi-stage builds, the /product_uuid path should be disabled. If not, the build fails in certain cases.

Error message:
```
[INFO] ------------------------------------------------------------------------
INFO[0123] Taking snapshot of full filesystem...
INFO[0128] Saving file home/kogito/serverless-workflow-project/target/quarkus-app/lib for later use
INFO[0128] Saving file home/kogito/serverless-workflow-project/target/quarkus-app/quarkus-run.jar for later use
INFO[0128] Saving file home/kogito/serverless-workflow-project/target/quarkus-app/app for later use
INFO[0128] Saving file home/kogito/serverless-workflow-project/target/quarkus-app/quarkus for later use
INFO[0128] Deleting filesystem...
error building image: deleting file system after stage 0: unlinkat //product_uuid: device or resource busy
```