### PR TITLE
[KOGITO-8794] - Making deployment handler profile independent

### DIFF
--- a/controllers/platform/warm.go
+++ b/controllers/platform/warm.go
@@ -70,7 +70,7 @@ func (action *warmAction) Handle(ctx context.Context, platform *operatorapi.Sona
 	switch pod.Status.Phase {
 	case corev1.PodSucceeded:
 		klog.V(log.D).InfoS("Kaniko cache successfully warmed up")
-		platform.Status.Manager().MarkFalse(api.SucceedConditionType, operatorapi.PlatformWarmingReason, "Kaniko cache successfully warmed up")
+		platform.Status.Manager().MarkTrueWithReason(api.SucceedConditionType, operatorapi.PlatformWarmingReason, "Kaniko cache successfully warmed up")
 		return platform, nil
 	case corev1.PodFailed:
 		return nil, errors.New("failed to warm up Kaniko cache")

--- a/controllers/profiles/deployment.go
+++ b/controllers/profiles/deployment.go
@@ -1,0 +1,103 @@
+// Copyright 2023 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiles
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kiegroup/kogito-serverless-operator/api"
+	operatorapi "github.com/kiegroup/kogito-serverless-operator/api/v1alpha08"
+	"github.com/kiegroup/kogito-serverless-operator/log"
+	kubeutil "github.com/kiegroup/kogito-serverless-operator/utils/kubernetes"
+)
+
+var _ WorkflowDeploymentHandler = &deploymentHandler{}
+
+// WorkflowDeploymentHandler interface to handle workflow deployment features.
+type WorkflowDeploymentHandler interface {
+	// SyncDeploymentStatus updates the workflow status aligned with the deployment counterpart.
+	// For example, if the deployment is in a failed state, it sets the status to
+	// Running `false` and the Message and Reason to human-readable format.
+	SyncDeploymentStatus(ctx context.Context, workflow *operatorapi.SonataFlow) (ctrl.Result, error)
+}
+
+// DeploymentHandler creates a new WorkflowDeploymentHandler implementation based on the current profile.
+func DeploymentHandler(c client.Client) WorkflowDeploymentHandler {
+	return &deploymentHandler{c: c}
+}
+
+type deploymentHandler struct {
+	c client.Client
+}
+
+func (d deploymentHandler) SyncDeploymentStatus(ctx context.Context, workflow *operatorapi.SonataFlow) (ctrl.Result, error) {
+	deployment := &appsv1.Deployment{}
+	if err := d.c.Get(ctx, client.ObjectKeyFromObject(workflow), deployment); err != nil {
+		// we should have the deployment by this time, so even if the error above is not found, we should halt.
+		workflow.Status.Manager().MarkFalse(api.RunningConditionType, api.DeploymentUnavailableReason, "Couldn't find the workflow deployment")
+		return ctrl.Result{RequeueAfter: requeueAfterFailure}, err
+	}
+
+	// Deployment is available, we can return after setting Running = TRUE
+	if kubeutil.IsDeploymentAvailable(deployment) {
+		workflow.Status.Manager().MarkTrue(api.RunningConditionType)
+		klog.V(log.I).InfoS("Workflow is in Running Condition")
+		return ctrl.Result{RequeueAfter: requeueAfterIsRunning}, nil
+	}
+
+	// Deployment should be progressing, Running = FALSE
+	// Wait for the next reconciliation
+	if kubeutil.IsDeploymentProgressing(deployment) {
+		workflow.Status.Manager().MarkFalse(api.RunningConditionType, api.WaitingForDeploymentReason, "")
+		klog.V(log.I).InfoS("Workflow is in WaitingForDeployment Condition")
+		return ctrl.Result{RequeueAfter: requeueAfterFollowDeployment}, nil
+	}
+
+	// Deployment hasn't minimum replicas, let's find out why to give users a meaningful information
+	if kubeutil.IsDeploymentMinimumReplicasUnavailable(deployment) {
+		message, err := kubeutil.DeploymentTroubleshooter(d.c, deployment, defaultContainerName).ReasonMessage()
+		if err != nil {
+			return ctrl.Result{RequeueAfter: requeueAfterFailure}, err
+		}
+		klog.V(log.I).InfoS("Workflow is not in Running condition duo to a deployment unavailability issue")
+		workflow.Status.Manager().MarkFalse(api.RunningConditionType, api.DeploymentUnavailableReason, message)
+		return ctrl.Result{RequeueAfter: requeueAfterFailure}, nil
+	}
+
+	// Fallback to a general failure message if we can't determine if the deployment has minimum replicas available.
+	failedReason := getDeploymentUnavailabilityMessage(deployment)
+	workflow.Status.LastTimeRecoverAttempt = metav1.Now()
+	workflow.Status.Manager().MarkFalse(api.RunningConditionType, api.DeploymentFailureReason, failedReason)
+	klog.V(log.I).InfoS("Workflow deployment failed", "Reason Message", failedReason)
+	return ctrl.Result{RequeueAfter: requeueAfterFailure}, nil
+}
+
+// getDeploymentUnavailabilityMessage gets the replica failure reason.
+// MUST be called after checking that the Deployment is NOT available.
+// If there's no reason, the Deployment state has no apparent reason to be in failed state.
+func getDeploymentUnavailabilityMessage(deployment *appsv1.Deployment) string {
+	failure := kubeutil.GetDeploymentUnavailabilityMessage(deployment)
+	if len(failure) == 0 {
+		failure = fmt.Sprintf("Workflow Deployment %s is unavailable", deployment.Name)
+	}
+	return failure
+}

--- a/controllers/profiles/object_creators.go
+++ b/controllers/profiles/object_creators.go
@@ -92,6 +92,7 @@ func defaultDeploymentCreator(workflow *operatorapi.SonataFlow) (client.Object, 
 							Name:          "http",
 							Protocol:      corev1.ProtocolTCP,
 						}},
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/controllers/sonataflowplatform_controller.go
+++ b/controllers/sonataflowplatform_controller.go
@@ -147,7 +147,7 @@ func (r *SonataFlowPlatformReconciler) Reconcile(ctx context.Context, req reconc
 		}
 	}
 
-	if target.Status.IsReady() {
+	if target != nil && target.Status.IsReady() {
 		return reconcile.Result{}, nil
 	}
 

--- a/utils/kubernetes/deployment.go
+++ b/utils/kubernetes/deployment.go
@@ -23,15 +23,19 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+const (
+	// this const is available here https://github.com/kubernetes/kubernetes/blob/6e0cb243d57592c917fe449dde20b0e246bc66be/pkg/controller/deployment/util/deployment_util.go#L100
+	// but it doesn't worth the dependency.
+	deploymentMinimumReplicasUnavailable = "MinimumReplicasUnavailable"
+)
+
 // IsDeploymentAvailable verifies if the Deployment conditions match the Available status
 func IsDeploymentAvailable(deployment *appsv1.Deployment) bool {
-	for _, condition := range deployment.Status.Conditions {
-		if condition.Type == appsv1.DeploymentAvailable &&
-			condition.Status == v1.ConditionTrue {
-			return true
-		}
-	}
-	return false
+	return isDeploymentInCondition(deployment, appsv1.DeploymentAvailable, v1.ConditionTrue)
+}
+
+func IsDeploymentProgressing(deployment *appsv1.Deployment) bool {
+	return isDeploymentInCondition(deployment, appsv1.DeploymentProgressing, v1.ConditionTrue)
 }
 
 // IsDeploymentFailed returns true in case of Deployment not available (IsDeploymentAvailable returns false) or it has a condition of
@@ -40,9 +44,25 @@ func IsDeploymentFailed(deployment *appsv1.Deployment) bool {
 	if IsDeploymentAvailable(deployment) {
 		return false
 	}
+	return isDeploymentInCondition(deployment, appsv1.DeploymentReplicaFailure, v1.ConditionTrue)
+}
+
+func isDeploymentInCondition(deployment *appsv1.Deployment, conditionType appsv1.DeploymentConditionType, status v1.ConditionStatus) bool {
 	for _, condition := range deployment.Status.Conditions {
-		if condition.Type == appsv1.DeploymentReplicaFailure &&
-			condition.Status == v1.ConditionTrue {
+		if condition.Type == conditionType &&
+			condition.Status == status {
+			return true
+		}
+	}
+	return false
+}
+
+// IsDeploymentMinimumReplicasUnavailable verifies if the deployment has the minimum replicas available
+func IsDeploymentMinimumReplicasUnavailable(deployment *appsv1.Deployment) bool {
+	for _, condition := range deployment.Status.Conditions {
+		if condition.Type == appsv1.DeploymentAvailable &&
+			condition.Status == v1.ConditionFalse &&
+			condition.Reason == deploymentMinimumReplicasUnavailable {
 			return true
 		}
 	}

--- a/utils/kubernetes/deployment.go
+++ b/utils/kubernetes/deployment.go
@@ -34,10 +34,6 @@ func IsDeploymentAvailable(deployment *appsv1.Deployment) bool {
 	return isDeploymentInCondition(deployment, appsv1.DeploymentAvailable, v1.ConditionTrue)
 }
 
-func IsDeploymentProgressing(deployment *appsv1.Deployment) bool {
-	return isDeploymentInCondition(deployment, appsv1.DeploymentProgressing, v1.ConditionTrue)
-}
-
 // IsDeploymentFailed returns true in case of Deployment not available (IsDeploymentAvailable returns false) or it has a condition of
 // DeploymentReplicaFailure == true.
 func IsDeploymentFailed(deployment *appsv1.Deployment) bool {

--- a/utils/kubernetes/deployment_failure.go
+++ b/utils/kubernetes/deployment_failure.go
@@ -1,0 +1,116 @@
+// Copyright 2023 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+/*
+Possible failure causes:
+
+1. Image not available (ImagePullFailure, ImagePullBackOff)
+- Nothing to do, signal an event that the image is wrong (fwd deployment error message)
+
+2. Exceeding resource limits (Pod Stucks on Pending) - verify ReplicaSet
+- Try to scale it back to 1
+
+3. Application failure, usually "CrashLoopBackOff"
+- Show the pod's log error in the event
+
+4. Ensure properties configMap is correctly defined ("RunContainerError")
+- Nothing to do, ensurer always do that
+
+5. Ensure that the mount volumes are there ("RunContainerError")
+- Nothing to do, ensurer always do that
+
+*/
+
+var _ DeploymentUnavailabilityReader = &deploymentUnavailabilityReader{}
+
+// DeploymentUnavailabilityReader implementations find the reason behind a deployment failure
+type DeploymentUnavailabilityReader interface {
+	// ReasonMessage returns the reason message in string format fetched from the culprit resource. For example, a Container status.
+	ReasonMessage() (string, error)
+}
+
+// DeploymentTroubleshooter creates a new DeploymentUnavailabilityReader for finding out why a deployment failed
+func DeploymentTroubleshooter(client client.Client, deployment *v1.Deployment, container string) DeploymentUnavailabilityReader {
+	return &deploymentUnavailabilityReader{
+		c:          client,
+		deployment: deployment,
+		container:  container,
+	}
+}
+
+type deploymentUnavailabilityReader struct {
+	c          client.Client
+	deployment *v1.Deployment
+	container  string
+}
+
+// ReasonMessage tries to find a human-readable reason message for why the deployment is not available or in a failed state.
+// This implementation fetches the given container status for this information.
+//
+// Future implementations might look in other objects for a more specific reason.
+// Additionally, future work might involve returning a typed Reason, so controllers may take actions depending on what have happened.
+func (d deploymentUnavailabilityReader) ReasonMessage() (string, error) {
+	podList := &corev1.PodList{}
+	// ideally we should get the latest replicaset, then the pods.
+	// problem is that we don't have a reliable field to get this information,
+	// it's in a message within the deployment status
+	// since this use case is only to show the deployment problem for user's troubleshooting, it's ok showing all of them.
+	// additionally, we are using a unique label identifier for matching
+	opts := &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(d.deployment.Spec.Selector.MatchLabels),
+		/*
+			FieldSelector: fields.AndSelectors(
+				fields.OneTermNotEqualSelector("status.phase", "Running"),
+				fields.OneTermNotEqualSelector("status.phase", "Succeeded")),
+
+		*/
+		Namespace: d.deployment.Namespace,
+	}
+
+	if err := d.c.List(context.TODO(), podList, opts); err != nil {
+		return "", err
+	}
+
+	for _, pod := range podList.Items {
+		if pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodSucceeded {
+			continue
+		}
+		for _, container := range pod.Status.ContainerStatuses {
+			if container.Name == d.container {
+				if !container.Ready {
+					if container.State.Waiting != nil {
+						return fmt.Sprintf("ContainerNotReady: (%s) %s", container.State.Waiting.Reason, container.State.Waiting.Message), nil
+					}
+					if container.State.Terminated != nil {
+						return fmt.Sprintf("ContainerNotReady: (%s) %s", container.State.Terminated.Reason, container.State.Terminated.Message), nil
+					}
+				}
+			}
+		}
+	}
+
+	return "", nil
+}

--- a/workflowproj/operator.go
+++ b/workflowproj/operator.go
@@ -27,8 +27,10 @@ const (
 	workflowConfigMapNameSuffix = "-props"
 	// ApplicationPropertiesFileName is the default application properties file name
 	ApplicationPropertiesFileName = "application.properties"
-	// LabelApp key to use among object selectors
+	// LabelApp key to use among object selectors, "app" is used among k8s applications to group objects in some UI consoles
 	LabelApp = "app"
+	// LabelWorkflow specialized label managed by the controller
+	LabelWorkflow = metadata.Domain + "/workflow-app"
 )
 
 // SetTypeToObject sets the Kind and ApiVersion to a given object since the default constructor won't do it.
@@ -66,7 +68,8 @@ func SetDefaultLabels(workflow *operatorapi.SonataFlow, object metav1.Object) {
 // You can use SetDefaultLabels that essentially does the same thing, if you don't need the labels explicitly.
 func GetDefaultLabels(workflow *operatorapi.SonataFlow) map[string]string {
 	return map[string]string{
-		LabelApp: workflow.Name,
+		LabelApp:      workflow.Name,
+		LabelWorkflow: workflow.Name,
 	}
 }
 


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
In this PR we made a few changes to the deployment handler to be the same for both profiles (dev and prod).
Also, there was a small bug in the `SonataFlowPlatform` in the warm action that prevented it to mark as a status `true`.

Additionally, now it's easier to spot a bug when something happens to the deployment and it has not reached the minimum replicas available.

**Motivation for the change:**
See JIRA https://issues.redhat.com/browse/KOGITO-8794

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>