### PR TITLE
[KOGITO-9748] Fix passing arguments to internal Kaniko builder

### DIFF
--- a/bundle/manifests/sonataflow-operator-builder-config_v1_configmap.yaml
+++ b/bundle/manifests/sonataflow-operator-builder-config_v1_configmap.yaml
@@ -2,9 +2,10 @@ apiVersion: v1
 data:
   DEFAULT_BUILDER_RESOURCE_NAME: Dockerfile
   DEFAULT_WORKFLOW_EXTENSION: .sw.json
-  Dockerfile: "FROM quay.io/kiegroup/kogito-swf-builder-nightly:latest AS builder\n
-    \ \n  # Copy from build context to skeleton resources project\nCOPY --chmod=644
-    * ./resources/\n\nRUN /home/kogito/launch/build-app.sh ./resources\n  \n  #=============================\n
+  Dockerfile: "FROM quay.io/kiegroup/kogito-swf-builder-nightly:latest AS builder\n\n
+    # variables that can be overridden by the builder\nARG QUARKUS_EXTENSIONS\n\n
+    \ # Copy from build context to skeleton resources project\nCOPY --chmod=644 *
+    ./resources/\n\nRUN /home/kogito/launch/build-app.sh ./resources\n  \n  #=============================\n
     \ # Runtime Run\n  #=============================\nFROM registry.access.redhat.com/ubi8/openjdk-11:latest\n\nENV
     LANG='en_US.UTF-8' LANGUAGE='en_US:en'\n  \n  # We make four distinct layers so
     if there are application changes the library layers can be re-used\nCOPY --from=builder

--- a/config/manager/sonataflow_builder_dockerfile.yaml
+++ b/config/manager/sonataflow_builder_dockerfile.yaml
@@ -1,5 +1,8 @@
 FROM quay.io/kiegroup/kogito-swf-builder-nightly:latest AS builder
-  
+
+ # variables that can be overridden by the builder
+ARG QUARKUS_EXTENSIONS
+
   # Copy from build context to skeleton resources project
 COPY --chmod=644 * ./resources/
 

--- a/operator.yaml
+++ b/operator.yaml
@@ -3018,9 +3018,10 @@ apiVersion: v1
 data:
   DEFAULT_BUILDER_RESOURCE_NAME: Dockerfile
   DEFAULT_WORKFLOW_EXTENSION: .sw.json
-  Dockerfile: "FROM quay.io/kiegroup/kogito-swf-builder-nightly:latest AS builder\n
-    \ \n  # Copy from build context to skeleton resources project\nCOPY --chmod=644
-    * ./resources/\n\nRUN /home/kogito/launch/build-app.sh ./resources\n  \n  #=============================\n
+  Dockerfile: "FROM quay.io/kiegroup/kogito-swf-builder-nightly:latest AS builder\n\n
+    # variables that can be overridden by the builder\nARG QUARKUS_EXTENSIONS\n\n
+    \ # Copy from build context to skeleton resources project\nCOPY --chmod=644 *
+    ./resources/\n\nRUN /home/kogito/launch/build-app.sh ./resources\n  \n  #=============================\n
     \ # Runtime Run\n  #=============================\nFROM registry.access.redhat.com/ubi8/openjdk-11:latest\n\nENV
     LANG='en_US.UTF-8' LANGUAGE='en_US:en'\n  \n  # We make four distinct layers so
     if there are application changes the library layers can be re-used\nCOPY --from=builder


### PR DESCRIPTION
**Description of the change:**
In this PR, we fix a problem when passing a few variables defined on `.spec.template` in `SonataFlowBuild`. Also, it was impossible to override the `QUARKUS_EXTENSIONS` env variable without `ARG` in our builder dockerfile. It was used to do an integration test with kaniko `--build-arg`.

TODO

- [ ] - Submit a doc update to teach users how to add custom extensions when building applications.

Relates to (not dependant):

- https://github.com/kiegroup/kogito-images/pull/1678

**Motivation for the change:**
See: https://issues.redhat.com/browse/KOGITO-9748

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>