### PR TITLE
Fix property expansion problem

### DIFF
--- a/controllers/profiles/object_creators.go
+++ b/controllers/profiles/object_creators.go
@@ -256,6 +256,9 @@ func ensureWorkflowPropertiesConfigMapMutator(workflow *operatorapi.SonataFlow, 
 				originalProps := properties.MustLoadString(original.(*corev1.ConfigMap).Data[workflowproj.ApplicationPropertiesFileName])
 				// we overwrite with the defaults
 				props.Merge(originalProps)
+				// Disable expansions since it's not our responsibility
+				// Property expansion means resolving ${} within the properties and environment context. Quarkus will do that in runtime.
+				props.DisableExpansion = true
 				cm.Data[workflowproj.ApplicationPropertiesFileName] = props.String()
 			}
 

--- a/controllers/profiles/object_creators_test.go
+++ b/controllers/profiles/object_creators_test.go
@@ -17,40 +17,29 @@ package profiles
 import (
 	"testing"
 
-	"github.com/magiconair/properties"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
-
-	"github.com/kiegroup/kogito-serverless-operator/workflowproj"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kiegroup/kogito-serverless-operator/test"
+	"github.com/kiegroup/kogito-serverless-operator/workflowproj"
 )
 
-func Test_ensureWorkflowPropertiesConfigMapMutator(t *testing.T) {
+func Test_ensureWorkflowPropertiesConfigMapMutator_DollarReplacement(t *testing.T) {
 	workflow := test.GetBaseSonataFlowWithDevProfile(t.Name())
-	// can't be new
-	cm, _ := workflowPropsConfigMapCreator(workflow)
-	cm.SetUID("1")
-	cm.SetResourceVersion("1")
-	reflectCm := cm.(*v1.ConfigMap)
+	existingCM := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      workflow.Name,
+			Namespace: workflow.Namespace,
+			UID:       "0000-0001-0002-0003",
+		},
+		Data: map[string]string{
+			workflowproj.ApplicationPropertiesFileName: "mp.messaging.outgoing.kogito_outgoing_stream.url=${kubernetes:services.v1/event-listener}",
+		},
+	}
+	mutateVisitorFn := ensureWorkflowPropertiesConfigMapMutator(workflow, defaultProdApplicationProperties)
 
-	visitor := ensureWorkflowDevPropertiesConfigMapMutator(workflow)
-	mutateFn := visitor(cm)
-
-	assert.NoError(t, mutateFn())
-	assert.NotEmpty(t, reflectCm.Data[workflowproj.ApplicationPropertiesFileName])
-
-	props := properties.MustLoadString(reflectCm.Data[workflowproj.ApplicationPropertiesFileName])
-	assert.Equal(t, "8080", props.GetString("quarkus.http.port", ""))
-
-	// we change the properties to something different, we add ours and change the default
-	reflectCm.Data[workflowproj.ApplicationPropertiesFileName] = "quarkus.http.port=9090\nmy.new.prop=1"
-	visitor(reflectCm)
-	assert.NoError(t, mutateFn())
-
-	// we should preserve the default, and still got ours
-	props = properties.MustLoadString(reflectCm.Data[workflowproj.ApplicationPropertiesFileName])
-	assert.Equal(t, "8080", props.GetString("quarkus.http.port", ""))
-	assert.Equal(t, "0.0.0.0", props.GetString("quarkus.http.host", ""))
-	assert.Equal(t, "1", props.GetString("my.new.prop", ""))
+	err := mutateVisitorFn(existingCM)()
+	assert.NoError(t, err)
+	assert.Contains(t, existingCM.Data[workflowproj.ApplicationPropertiesFileName], "${kubernetes:services.v1/event-listener}")
 }

--- a/controllers/profiles/object_creators_test.go
+++ b/controllers/profiles/object_creators_test.go
@@ -17,6 +17,7 @@ package profiles
 import (
 	"testing"
 
+	"github.com/magiconair/properties"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +25,35 @@ import (
 	"github.com/kiegroup/kogito-serverless-operator/test"
 	"github.com/kiegroup/kogito-serverless-operator/workflowproj"
 )
+
+func Test_ensureWorkflowPropertiesConfigMapMutator(t *testing.T) {
+	workflow := test.GetBaseSonataFlowWithDevProfile(t.Name())
+	// can't be new
+	cm, _ := workflowPropsConfigMapCreator(workflow)
+	cm.SetUID("1")
+	cm.SetResourceVersion("1")
+	reflectCm := cm.(*v1.ConfigMap)
+
+	visitor := ensureWorkflowDevPropertiesConfigMapMutator(workflow)
+	mutateFn := visitor(cm)
+
+	assert.NoError(t, mutateFn())
+	assert.NotEmpty(t, reflectCm.Data[workflowproj.ApplicationPropertiesFileName])
+
+	props := properties.MustLoadString(reflectCm.Data[workflowproj.ApplicationPropertiesFileName])
+	assert.Equal(t, "8080", props.GetString("quarkus.http.port", ""))
+
+	// we change the properties to something different, we add ours and change the default
+	reflectCm.Data[workflowproj.ApplicationPropertiesFileName] = "quarkus.http.port=9090\nmy.new.prop=1"
+	visitor(reflectCm)
+	assert.NoError(t, mutateFn())
+
+	// we should preserve the default, and still got ours
+	props = properties.MustLoadString(reflectCm.Data[workflowproj.ApplicationPropertiesFileName])
+	assert.Equal(t, "8080", props.GetString("quarkus.http.port", ""))
+	assert.Equal(t, "0.0.0.0", props.GetString("quarkus.http.host", ""))
+	assert.Equal(t, "1", props.GetString("my.new.prop", ""))
+}
 
 func Test_ensureWorkflowPropertiesConfigMapMutator_DollarReplacement(t *testing.T) {
 	workflow := test.GetBaseSonataFlowWithDevProfile(t.Name())

--- a/test/testdata/order-processing/04_v1_configmap_properties.yaml
+++ b/test/testdata/order-processing/04_v1_configmap_properties.yaml
@@ -19,4 +19,4 @@ metadata:
 data:
   application.properties: |
     quarkus.log.level = INFO
-    mp.messaging.outgoing.kogito_outgoing_stream.url = kubernetes:services.v1/event-listener
+    mp.messaging.outgoing.kogito_outgoing_stream.url = ${kubernetes:services.v1/event-listener}

--- a/test/testdata/order-processing/README.md
+++ b/test/testdata/order-processing/README.md
@@ -1,0 +1,3 @@
+# Order Processing Example
+
+See: https://github.com/kiegroup/kogito-examples/tree/main/serverless-workflow-examples/serverless-workflow-order-processing


### PR DESCRIPTION
**Description of the change:**
In this PR, we fixed a bug where the internal operator's properties parsing is trying to expand `${}`.

**Motivation for the change:**
See https://issues.redhat.com/browse/KOGITO-9773

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>