### PR TITLE
[9.99.x-prod][SRVLOGIC-219] - Update codebase to reflect OSL 1.32 images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 2.0.0-snapshot
-REDUCED_VERSION ?= latest
+REDUCED_VERSION ?= 1.32.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -30,7 +30,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # kiegroup.org/kogito-serverless-operator-bundle:$VERSION and kiegroup.org/kogito-serverless-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/kiegroup/kogito-serverless-operator-nightly
+IMAGE_TAG_BASE ?= registry.redhat.io/openshift-serverless-1-tech-preview/logic-rhel8-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/bundle/manifests/sonataflow-operator-builder-config_v1_configmap.yaml
+++ b/bundle/manifests/sonataflow-operator-builder-config_v1_configmap.yaml
@@ -2,16 +2,17 @@ apiVersion: v1
 data:
   DEFAULT_BUILDER_RESOURCE_NAME: Dockerfile
   DEFAULT_WORKFLOW_EXTENSION: .sw.json
-  Dockerfile: "FROM quay.io/kiegroup/kogito-swf-builder-nightly:latest AS builder\n\n#
-    variables that can be overridden by the builder\n# To add a Quarkus extension
-    to your application\nARG QUARKUS_EXTENSIONS\n# Args to pass to the Quarkus CLI
-    add extension command\nARG QUARKUS_ADD_EXTENSION_ARGS\n\n# Copy from build context
-    to skeleton resources project\nCOPY --chown=1001 . ./resources\n\nRUN /home/kogito/launch/build-app.sh
-    ./resources\n  \n#=============================\n# Runtime Run\n#=============================\nFROM
-    registry.access.redhat.com/ubi9/openjdk-17:latest\n\nENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'\n
-    \ \n# We make four distinct layers so if there are application changes the library
-    layers can be re-used\nCOPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/lib/
-    /deployments/lib/\nCOPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/*.jar
+  Dockerfile: "FROM registry.redhat.io/openshift-serverless-1-tech-preview/logic-swf-builder-rhel8:1.32.0
+    AS builder\n\n# variables that can be overridden by the builder\n# To add a Quarkus
+    extension to your application\nARG QUARKUS_EXTENSIONS\n# Args to pass to the Quarkus
+    CLI add extension command\nARG QUARKUS_ADD_EXTENSION_ARGS\n\n# Copy from build
+    context to skeleton resources project\nCOPY --chown=1001 . ./resources\n\nRUN
+    /home/kogito/launch/build-app.sh ./resources\n  \n#=============================\n#
+    Runtime Run\n#=============================\nFROM registry.access.redhat.com/ubi9/openjdk-17:latest\n\nENV
+    LANG='en_US.UTF-8' LANGUAGE='en_US:en'\n  \n# We make four distinct layers so
+    if there are application changes the library layers can be re-used\nCOPY --from=builder
+    --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/lib/ /deployments/lib/\nCOPY
+    --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/*.jar
     /deployments/\nCOPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/app/
     /deployments/app/\nCOPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/quarkus/
     /deployments/quarkus/\n\nEXPOSE 8080\nUSER 185\nENV AB_JOLOKIA_OFF=\"\"\nENV JAVA_OPTS=\"-Dquarkus.http.host=0.0.0.0

--- a/bundle/manifests/sonataflow-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sonataflow-operator.clusterserviceversion.yaml
@@ -119,7 +119,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Application Runtime
-    containerImage: quay.io/kiegroup/kogito-serverless-operator-nightly:latest
+    containerImage: registry.redhat.io/openshift-serverless-1-tech-preview/logic-rhel8-operator:1.32.0
     description: SonataFlow Kubernetes Operator for deploying workflow applications
       based on the CNCF Serverless Workflow specification
     operators.operatorframework.io/builder: operator-sdk-v1.25.0
@@ -704,7 +704,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kiegroup/kogito-serverless-operator-nightly:latest
+                image: registry.redhat.io/openshift-serverless-1-tech-preview/logic-rhel8-operator:1.32.0
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,8 +16,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/kiegroup/kogito-serverless-operator-nightly
-  newTag: latest
+  newName: registry.redhat.io/openshift-serverless-1-tech-preview/logic-rhel8-operator
+  newTag: 1.32.0
 # Patching the manager deployment file to add an env var with the operator namespace in
 patchesJson6902:
 - patch: |-

--- a/config/manager/sonataflow_builder_dockerfile.yaml
+++ b/config/manager/sonataflow_builder_dockerfile.yaml
@@ -1,4 +1,4 @@
-FROM quay.io/kiegroup/kogito-swf-builder-nightly:latest AS builder
+FROM registry.redhat.io/openshift-serverless-1-tech-preview/logic-swf-builder-rhel8:1.32.0 AS builder
 
 # variables that can be overridden by the builder
 # To add a Quarkus extension to your application

--- a/config/manifests/bases/sonataflow-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sonataflow-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Application Runtime
-    containerImage: quay.io/kiegroup/kogito-serverless-operator-nightly:latest
+    containerImage: registry.redhat.io/openshift-serverless-1-tech-preview/logic-rhel8-operator:1.32.0
     description: SonataFlow Kubernetes Operator for deploying workflow applications
       based on the CNCF Serverless Workflow specification
     operators.operatorframework.io/internal-objects: '["sonataflowbuilds.sonataflow.org"]'

--- a/config/manifests/osl/bases/logic-operator-rhel8.clusterserviceversion.yaml
+++ b/config/manifests/osl/bases/logic-operator-rhel8.clusterserviceversion.yaml
@@ -225,7 +225,7 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: registry.redhat.io/openshift-serverless-1-tech-preview/logic-operator-rhel8:1.32.0
+  - image: registry.redhat.io/openshift-serverless-1-tech-preview/logic-rhel8-operator:1.32.0
     name: IMAGE_LOGIC_SWF_OPERATOR
   - image: registry.redhat.io/openshift-serverless-1-tech-preview/logic-swf-devmode-rhel8:1.32.0
     name: IMAGE_LOGIC_SWF_DEVMODE

--- a/container-builder/examples/dockerfiles/SonataFlow.dockerfile
+++ b/container-builder/examples/dockerfiles/SonataFlow.dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM quay.io/kiegroup/kogito-swf-builder-nightly:latest AS builder
+FROM registry.redhat.io/openshift-serverless-1-tech-preview/logic-rhel8-operator:1.32.0 AS builder
 
 # Kogito User
 USER 1001

--- a/controllers/platform/services/services.go
+++ b/controllers/platform/services/services.go
@@ -101,13 +101,13 @@ func (d DataIndexHandler) GetContainerName() string {
 }
 
 func (d DataIndexHandler) GetServiceImageName(persistenceName string) string {
-	var tag = version.GetMajorMinor()
-	var suffix = ""
-	if version.IsSnapshot() {
-		tag = "latest"
-		//TODO, remove
-		suffix = constants.ImageNameNightlySuffix
+	// Fix for OSL 1.32 where we only have DI ephemeral image.
+	if persistenceName == "ephemeral" {
+		return "registry.redhat.io/openshift-serverless-1-tech-preview/logic-rhel8-operator:" + version.OperatorVersion
 	}
+	// Since we don't have an upstream version so far, use latest nightly
+	var tag = "latest"
+	var suffix = constants.ImageNameNightlySuffix
 	// returns "quay.io/kiegroup/kogito-data-index-<persistence_layer>:<tag>"
 	return fmt.Sprintf("%s-%s-%s:%s", constants.ImageNamePrefix, constants.DataIndexName, persistenceName+suffix, tag)
 }
@@ -257,13 +257,9 @@ func (j JobServiceHandler) GetContainerName() string {
 }
 
 func (j JobServiceHandler) GetServiceImageName(persistenceName string) string {
-	var tag = version.GetMajorMinor()
-	var suffix = ""
-	if version.IsSnapshot() {
-		tag = "latest"
-		//TODO remove
-		suffix = constants.ImageNameNightlySuffix
-	}
+	// Use latest nightly since we don't have a release upstream nor a prod version of Jobs Service
+	var tag = "latest"
+	var suffix = constants.ImageNameNightlySuffix
 	// returns "quay.io/kiegroup/kogito-jobs-service-<persistece_layer>:<tag>"
 	return fmt.Sprintf("%s-%s-%s:%s", constants.ImageNamePrefix, constants.JobServiceName, persistenceName+suffix, tag)
 }

--- a/controllers/platform/services/services.go
+++ b/controllers/platform/services/services.go
@@ -103,7 +103,7 @@ func (d DataIndexHandler) GetContainerName() string {
 func (d DataIndexHandler) GetServiceImageName(persistenceName string) string {
 	// Fix for OSL 1.32 where we only have DI ephemeral image.
 	if persistenceName == "ephemeral" {
-		return "registry.redhat.io/openshift-serverless-1-tech-preview/logic-rhel8-operator:" + version.OperatorVersion
+		return "registry.redhat.io/openshift-serverless-1-tech-preview/logic-data-index-ephemeral-rhel8:" + version.OperatorVersion
 	}
 	// Since we don't have an upstream version so far, use latest nightly
 	var tag = "latest"

--- a/controllers/workflowdef/image.go
+++ b/controllers/workflowdef/image.go
@@ -28,9 +28,9 @@ import (
 const (
 	latestImageTag              = "latest"
 	nightlySuffix               = "nightly"
-	defaultWorkflowDevModeImage = "quay.io/kiegroup/kogito-swf-devmode"
-	defaultWorkflowBuilderImage = "quay.io/kiegroup/kogito-swf-builder"
-	defaultOperatorImage        = "quay.io/kiegroup/kogito-serverless-operator"
+	defaultWorkflowDevModeImage = "registry.redhat.io/openshift-serverless-1-tech-preview/logic-swf-devmode-rhel8"
+	defaultWorkflowBuilderImage = "registry.redhat.io/openshift-serverless-1-tech-preview/logic-swf-builder-rhel8"
+	defaultOperatorImage        = "registry.redhat.io/openshift-serverless-1-tech-preview/logic-rhel8-operator"
 )
 
 // GetWorkflowAppImageNameTag retrieve the tag for the image based on the Workflow based annotation, <workflowid>:latest otherwise
@@ -55,14 +55,6 @@ func GetDefaultOperatorImageTag() string {
 }
 
 func GetDefaultImageTag(imgTag string) string {
-	if version.IsSnapshot() {
-		imgTag += "-" + nightlySuffix
-	}
-	imgTag += ":"
-	if version.IsLatestVersion() {
-		imgTag += latestImageTag
-	} else {
-		imgTag += version.GetMajorMinor()
-	}
+	imgTag += ":" + version.OperatorVersion
 	return imgTag
 }

--- a/operator.yaml
+++ b/operator.yaml
@@ -26693,16 +26693,17 @@ apiVersion: v1
 data:
   DEFAULT_BUILDER_RESOURCE_NAME: Dockerfile
   DEFAULT_WORKFLOW_EXTENSION: .sw.json
-  Dockerfile: "FROM quay.io/kiegroup/kogito-swf-builder-nightly:latest AS builder\n\n#
-    variables that can be overridden by the builder\n# To add a Quarkus extension
-    to your application\nARG QUARKUS_EXTENSIONS\n# Args to pass to the Quarkus CLI
-    add extension command\nARG QUARKUS_ADD_EXTENSION_ARGS\n\n# Copy from build context
-    to skeleton resources project\nCOPY --chown=1001 . ./resources\n\nRUN /home/kogito/launch/build-app.sh
-    ./resources\n  \n#=============================\n# Runtime Run\n#=============================\nFROM
-    registry.access.redhat.com/ubi9/openjdk-17:latest\n\nENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'\n
-    \ \n# We make four distinct layers so if there are application changes the library
-    layers can be re-used\nCOPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/lib/
-    /deployments/lib/\nCOPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/*.jar
+  Dockerfile: "FROM registry.redhat.io/openshift-serverless-1-tech-preview/logic-swf-builder-rhel8:1.32.0
+    AS builder\n\n# variables that can be overridden by the builder\n# To add a Quarkus
+    extension to your application\nARG QUARKUS_EXTENSIONS\n# Args to pass to the Quarkus
+    CLI add extension command\nARG QUARKUS_ADD_EXTENSION_ARGS\n\n# Copy from build
+    context to skeleton resources project\nCOPY --chown=1001 . ./resources\n\nRUN
+    /home/kogito/launch/build-app.sh ./resources\n  \n#=============================\n#
+    Runtime Run\n#=============================\nFROM registry.access.redhat.com/ubi9/openjdk-17:latest\n\nENV
+    LANG='en_US.UTF-8' LANGUAGE='en_US:en'\n  \n# We make four distinct layers so
+    if there are application changes the library layers can be re-used\nCOPY --from=builder
+    --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/lib/ /deployments/lib/\nCOPY
+    --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/*.jar
     /deployments/\nCOPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/app/
     /deployments/app/\nCOPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/quarkus/
     /deployments/quarkus/\n\nEXPOSE 8080\nUSER 185\nENV AB_JOLOKIA_OFF=\"\"\nENV JAVA_OPTS=\"-Dquarkus.http.host=0.0.0.0
@@ -26804,7 +26805,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kiegroup/kogito-serverless-operator-nightly:latest
+        image: registry.redhat.io/openshift-serverless-1-tech-preview/logic-rhel8-operator:1.32.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/version/version.go
+++ b/version/version.go
@@ -19,28 +19,11 @@
 
 package version
 
-import (
-	"strings"
-)
-
 const (
 	// Current version
-	OperatorVersion = "2.0.0-snapshot"
+	OperatorVersion = "1.32.0"
 
 	// Should not be changed
 	snapshotSuffix = "snapshot"
 	latestVersion  = "2.0.0-snapshot"
 )
-
-func IsSnapshot() bool {
-	return strings.HasSuffix(OperatorVersion, snapshotSuffix)
-}
-
-func IsLatestVersion() bool {
-	return latestVersion == OperatorVersion
-}
-
-func GetMajorMinor() string {
-	v := strings.Split(OperatorVersion, ".")
-	return v[0] + "." + v[1]
-}


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
In this PR, we do a small update to reflect the OSL 1.32 images. There's a small workaround in the `version.go` and `services.go` files to handle the Data Index ephemeral OSL image and to fallback to upstream.

**Motivation for the change:**
See https://issues.redhat.com/browse/SRVLOGIC-219


**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>