### PR TITLE
do not run upstream-sync.yml GHA for fork repositories

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   sync-main-apache:
+    if: github.repository_owner == 'kiegroup'
     name: Sync main-apache branch
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This is to avoid running this GHA in the user's fork, as it will fail because it does not have the kie-ci token configured and we probably dont want anyway to run this action in our fork, just in kiegroup org.

Related PRs:
- https://github.com/kiegroup/drools/pull/24
- https://github.com/kiegroup/kogito-runtimes/pull/20
- https://github.com/kiegroup/kogito-apps/pull/11
- https://github.com/kiegroup/kogito-examples/pull/14
- https://github.com/kiegroup/kogito-images/pull/11
- https://github.com/kiegroup/kogito-serverless-operator/pull/15

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>