### PR TITLE
[9.99.x-prod][SRVLOGIC-228] Investigate why non-dev scenarios now requires JDBC configuration

### DIFF
--- a/controllers/builder/containerbuilder.go
+++ b/controllers/builder/containerbuilder.go
@@ -138,7 +138,7 @@ func (c *containerBuilderManager) scheduleNewKanikoBuildWithContainerFile(build 
 		workflowDefinition: workflowDef,
 		workflow:           workflow,
 		dockerfile:         platform.GetCustomizedDockerfile(c.commonConfig.Data[c.commonConfig.Data[configKeyDefaultBuilderResourceName]], *c.platform),
-		imageTag:           workflowdef.GetWorkflowAppImageNameTag(workflow),
+		imageTag:           buildNamespacedImageTag(workflow),
 	}
 
 	if c.platform.Spec.Build.Config.Timeout == nil {
@@ -198,4 +198,11 @@ func newBuild(buildInput kanikoBuildInput, platform api.PlatformContainerBuild, 
 		WithResourceRequirements(buildInput.task.Resources).
 		WithBuildArgs(buildInput.task.BuildArgs).
 		WithEnvs(buildInput.task.Envs).Schedule()
+}
+
+// buildNamespacedImageTag For the kaniko build we prepend the namespace to the calculated image name/tag to avoid potential
+// collisions if the same workflows is deployed in a different namespace. In OpenShift this last is not needed since the
+// ImageStreams are already namespaced.
+func buildNamespacedImageTag(workflow *operatorapi.SonataFlow) string {
+	return workflow.Namespace + "/" + workflowdef.GetWorkflowAppImageNameTag(workflow)
 }

--- a/controllers/workflowdef/image.go
+++ b/controllers/workflowdef/image.go
@@ -20,7 +20,6 @@
 package workflowdef
 
 import (
-	"github.com/apache/incubator-kie-kogito-serverless-operator/api/metadata"
 	"github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
 	"github.com/apache/incubator-kie-kogito-serverless-operator/version"
 )
@@ -33,12 +32,19 @@ const (
 	defaultOperatorImage        = "registry.redhat.io/openshift-serverless-1-tech-preview/logic-rhel8-operator"
 )
 
-// GetWorkflowAppImageNameTag retrieve the tag for the image based on the Workflow based annotation, <workflowid>:latest otherwise
+// GetWorkflowAppImageNameTag returns the image name with tag to use for the image to be produced for a given workflow.
+// Before, we generated the tags based on the workflow version annotation, however this produced the following undesired
+// effects. Empirically, it was detected that, if we deploy a workflow several times, for instance, the workflow is deleted
+// for a modification, and then deployed again. When the build cycle is produced, etc., if the workflow version
+// remains the same, e.g. 1.0.0, the bits for the new image are not written in the respective registry (because an image
+// with the given tag already exists), and thus, when the workflow executes the old bits are executed.
+// To avoid this, the workflow version must be changed, for example to 2.0.0, and thus the subsequent image will have
+// a different tag, and the expected bits will be stored at the registry and finally executed.
+// This workflow version bump must be produced by the users, but we don't have control over this.
+// So by now, considering that the operator images build is oriented to "dev" and "preview" scenarios, and
+// not for "production" scenarios, we decided to use "latest" as the tag. In that way, we ensure that the last image
+// produced bits will be used to execute a given workflow.
 func GetWorkflowAppImageNameTag(w *v1alpha08.SonataFlow) string {
-	v := w.Annotations[metadata.Version]
-	if v != "" {
-		return w.Name + ":" + v
-	}
 	return w.Name + ":" + latestImageTag
 }
 

--- a/test/e2e/platform_test.go
+++ b/test/e2e/platform_test.go
@@ -117,9 +117,9 @@ var _ = Describe("Validate the persistence", Ordered, func() {
 			}
 		},
 			Entry("with both Job Service and Data Index and ephemeral persistence and the workflow in a dev profile", test.GetSonataFlowE2EPlatformServicesDirectory(), dev, ephemeral),
-			XEntry("with both Job Service and Data Index and ephemeral persistence and the workflow in a production profile", test.GetSonataFlowE2EPlatformServicesDirectory(), production, ephemeral),
+			Entry("with both Job Service and Data Index and ephemeral persistence and the workflow in a production profile", test.GetSonataFlowE2EPlatformServicesDirectory(), production, ephemeral),
 			Entry("with both Job Service and Data Index and postgreSQL persistence and the workflow in a dev profile", test.GetSonataFlowE2EPlatformServicesDirectory(), dev, postgreSQL),
-			XEntry("with both Job Service and Data Index and postgreSQL persistence and the workflow in a production profile", test.GetSonataFlowE2EPlatformServicesDirectory(), production, postgreSQL),
+			Entry("with both Job Service and Data Index and postgreSQL persistence and the workflow in a production profile", test.GetSonataFlowE2EPlatformServicesDirectory(), production, postgreSQL),
 		)
 
 	})


### PR DESCRIPTION
    - kie-kogito-serverless-operator-379: Investigate why non-dev scenarios now requires JDBC configuration (#386)

    - Use "latest" image tag and namespaced images generation.

(cherry picked from commit df462a854fa1e879f72b90c02f2cae23df833008)

<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>