### PR TITLE
[9.99.x-prod][OSL-1.32.2] Propagate workflow labels to the its K8s resources (#413)

### DIFF
--- a/controllers/builder/openshiftbuilder.go
+++ b/controllers/builder/openshiftbuilder.go
@@ -117,8 +117,8 @@ func (o *openshiftBuilderManager) Schedule(build *operatorapi.SonataFlowBuild) e
 	if err = o.addExternalResources(bc, workflow); err != nil {
 		return err
 	}
-	workflowproj.SetDefaultLabels(workflow, is)
-	workflowproj.SetDefaultLabels(workflow, bc)
+	workflowproj.SetMergedLabels(workflow, is)
+	workflowproj.SetMergedLabels(workflow, bc)
 	if err = controllerutil.SetControllerReference(build, bc, o.buildManagerContext.client.Scheme()); err != nil {
 		return err
 	}

--- a/controllers/profiles/common/object_creators.go
+++ b/controllers/profiles/common/object_creators.go
@@ -72,7 +72,7 @@ var (
 // DeploymentCreator is an objectCreator for a base Kubernetes Deployments for profiles that need to deploy the workflow on a vanilla deployment.
 // It serves as a basis for a basic Quarkus Java application, expected to listen on http 8080.
 func DeploymentCreator(workflow *operatorapi.SonataFlow) (client.Object, error) {
-	lbl := workflowproj.GetDefaultLabels(workflow)
+	lbl := workflowproj.GetMergedLabels(workflow)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -184,7 +184,7 @@ func defaultContainer(workflow *operatorapi.SonataFlow) (*corev1.Container, erro
 // ServiceCreator is an objectCreator for a basic Service aiming a vanilla Kubernetes Deployment.
 // It maps the default HTTP port (80) to the target Java application webserver on port 8080.
 func ServiceCreator(workflow *operatorapi.SonataFlow) (client.Object, error) {
-	lbl := workflowproj.GetDefaultLabels(workflow)
+	lbl := workflowproj.GetMergedLabels(workflow)
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/profiles/dev/object_creators_dev.go
+++ b/controllers/profiles/dev/object_creators_dev.go
@@ -79,7 +79,6 @@ func workflowDefConfigMapCreator(workflow *operatorapi.SonataFlow) (client.Objec
 	if err != nil {
 		return nil, err
 	}
-	workflowproj.SetDefaultLabels(workflow, configMap)
 	return configMap, nil
 }
 

--- a/controllers/profiles/dev/object_creators_dev_test.go
+++ b/controllers/profiles/dev/object_creators_dev_test.go
@@ -41,4 +41,7 @@ func Test_ensureWorkflowDevServiceIsExposed(t *testing.T) {
 	assert.NotNil(t, reflectService.Spec.Type)
 	assert.NotEmpty(t, reflectService.Spec.Type)
 	assert.Equal(t, reflectService.Spec.Type, v1.ServiceTypeNodePort)
+	assert.NotNil(t, reflectService.ObjectMeta)
+	assert.NotNil(t, reflectService.ObjectMeta.Labels)
+	assert.Equal(t, reflectService.ObjectMeta.Labels, map[string]string{"test": "test", "app": "greeting", "sonataflow.org/workflow-app": "greeting"})
 }

--- a/controllers/profiles/prod/profile_prod_test.go
+++ b/controllers/profiles/prod/profile_prod_test.go
@@ -68,6 +68,9 @@ func Test_Reconciler_ProdOps(t *testing.T) {
 	assert.Len(t, deployment.Spec.Template.Spec.Containers, 1)
 	assert.Len(t, deployment.Spec.Template.Spec.InitContainers, 1)
 	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].VolumeMounts, 1)
+	assert.NotNil(t, deployment.ObjectMeta)
+	assert.NotNil(t, deployment.ObjectMeta.Labels)
+	assert.Equal(t, deployment.ObjectMeta.Labels, map[string]string{"test": "test", "app": "simple", "sonataflow.org/workflow-app": "simple"})
 }
 
 func Test_Reconciler_ProdCustomPod(t *testing.T) {
@@ -96,6 +99,9 @@ func Test_Reconciler_ProdCustomPod(t *testing.T) {
 	assert.Len(t, deployment.Spec.Template.Spec.Containers, 1)
 	assert.Len(t, deployment.Spec.Template.Spec.InitContainers, 1)
 	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].VolumeMounts, 1)
+	assert.NotNil(t, deployment.ObjectMeta)
+	assert.NotNil(t, deployment.ObjectMeta.Labels)
+	assert.Equal(t, deployment.ObjectMeta.Labels, map[string]string{"test": "test", "app": "greeting", "sonataflow.org/workflow-app": "greeting"})
 }
 
 func Test_reconcilerProdBuildConditions(t *testing.T) {

--- a/controllers/workflowdef/configmap.go
+++ b/controllers/workflowdef/configmap.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"path"
 
+	"github.com/apache/incubator-kie-kogito-serverless-operator/workflowproj"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,6 +49,7 @@ func CreateNewConfigMap(workflow *operatorapi.SonataFlow) (*corev1.ConfigMap, er
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      workflow.Name,
 			Namespace: workflow.Namespace,
+			Labels:    workflowproj.GetMergedLabels(workflow),
 		},
 		Data: map[string]string{GetWorkflowDefFileName(workflow): string(workflowDef)},
 	}, nil

--- a/test/testdata/sonataflow.org_v1alpha08_sonataflow-simpleops.yaml
+++ b/test/testdata/sonataflow.org_v1alpha08_sonataflow-simpleops.yaml
@@ -19,6 +19,9 @@ metadata:
   annotations:
     sonataflow.org/description: Simple example on k8s!
     sonataflow.org/version: 0.0.1
+  labels:
+    test: test
+    app: not-simple
 spec:
   podTemplate:
     container:

--- a/test/testdata/sonataflow.org_v1alpha08_sonataflow.yaml
+++ b/test/testdata/sonataflow.org_v1alpha08_sonataflow.yaml
@@ -22,6 +22,8 @@ metadata:
   annotations:
     sonataflow.org/description: Greeting example on k8s!
     sonataflow.org/version: 0.0.1
+  labels:
+    test: test
 spec:
   flow:
     start: ChooseOnLanguage

--- a/utils/openshift/route.go
+++ b/utils/openshift/route.go
@@ -33,6 +33,7 @@ func RouteForWorkflow(workflow *operatorapi.SonataFlow) (*v1.Route, error) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      workflow.Name,
 			Namespace: workflow.Namespace,
+			Labels:    workflowproj.GetMergedLabels(workflow),
 		},
 		Spec: v1.RouteSpec{
 			To: v1.RouteTargetReference{
@@ -44,6 +45,5 @@ func RouteForWorkflow(workflow *operatorapi.SonataFlow) (*v1.Route, error) {
 			},
 		},
 	}
-	workflowproj.SetDefaultLabels(workflow, route)
 	return route, nil
 }

--- a/workflowproj/workflowproj.go
+++ b/workflowproj/workflowproj.go
@@ -234,7 +234,7 @@ func (w *workflowProjectHandler) parseRawWorkflow() error {
 		profile = w.profile
 	}
 	SetWorkflowProfile(w.project.Workflow, profile)
-	SetDefaultLabels(w.project.Workflow, w.project.Workflow)
+	SetMergedLabels(w.project.Workflow, w.project.Workflow)
 	if err = SetTypeToObject(w.project.Workflow, w.scheme); err != nil {
 		return err
 	}

--- a/workflowproj/workflowproj_test.go
+++ b/workflowproj/workflowproj_test.go
@@ -76,6 +76,8 @@ func Test_Handler_WorkflowMinimalAndPropsAndSpec(t *testing.T) {
 		AsObjects()
 	assert.NoError(t, err)
 	assert.NotNil(t, proj.Workflow)
+	assert.NotNil(t, proj.Workflow.ObjectMeta)
+	assert.Equal(t, proj.Workflow.ObjectMeta.Labels, map[string]string{"app": "hello", "sonataflow.org/workflow-app": "hello"})
 	assert.NotNil(t, proj.Properties)
 	assert.NotEmpty(t, proj.Resources)
 	assert.Equal(t, "hello", proj.Workflow.Name)


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
Cherry Pick for https://github.com/apache/incubator-kie-kogito-serverless-operator/pull/413

**Motivation for the change:**
Release of OSL 1.32.2

**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>