### PR TITLE
update supported arches for kn-workflow-cli-artifacts image

### DIFF
--- a/images/modules/com.redhat.osl.cli.artifacts/install.sh
+++ b/images/modules/com.redhat.osl.cli.artifacts/install.sh
@@ -15,4 +15,4 @@
 
 set -e
 
-mkdir -p /usr/share/kn/{linux_amd64,linux_ppc64le,linux_s390x,macos,windows}
+mkdir -p /usr/share/kn/{linux_amd64,linux_arm64,macos_amd64,macos_arm64,windows}

--- a/images/modules/com.redhat.osl.cli.artifacts/module.yaml
+++ b/images/modules/com.redhat.osl.cli.artifacts/module.yaml
@@ -25,18 +25,18 @@ artifacts:
     path: /opt/app-root/src/go/src/github.com/knative/client/kn-workflow-linux-amd64.tar.gz
     dest: /usr/share/kn/linux_amd64/
   - image: packager
-    name: kn-workflow-linux-ppc64le
-    path: /opt/app-root/src/go/src/github.com/knative/client/kn-workflow-linux-ppc64le.tar.gz
-    dest: /usr/share/kn/linux_ppc64le/
-  - image: packager
-    name: kn-workflow-linux-s390x
-    path: /opt/app-root/src/go/src/github.com/knative/client/kn-workflow-linux-s390x.tar.gz
-    dest: /usr/share/kn/linux_s390x/
-  - image: packager
-    name: kn-workflow-macos-amd64
-    path: /opt/app-root/src/go/src/github.com/knative/client/kn-workflow-macos-amd64.tar.gz
-    dest: /usr/share/kn/macos/
+    name: kn-workflow-linux-arm64
+    path: /opt/app-root/src/go/src/github.com/knative/client/kn-workflow-linux-arm64.tar.gz
+    dest: /usr/share/kn/linux_arm64/
   - image: packager
     name: kn-workflow-windows-amd64
     path: /opt/app-root/src/go/src/github.com/knative/client/kn-workflow-windows-amd64.zip
     dest: /usr/share/kn/windows/
+  - image: packager
+    name: kn-workflow-macos-amd64
+    path: /opt/app-root/src/go/src/github.com/knative/client/kn-workflow-macos-amd64.tar.gz
+    dest: /usr/share/kn/macos_amd64/
+  - image: packager
+    name: kn-workflow-macos-arm64
+    path: /opt/app-root/src/go/src/github.com/knative/client/kn-workflow-macos-arm64.tar.gz
+    dest: /usr/share/kn/macos_arm64/

--- a/images/modules/com.redhat.osl.cli.artifacts/module.yaml
+++ b/images/modules/com.redhat.osl.cli.artifacts/module.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: "com.redhat.osl.cli.artifacts"
-version: "1.33.0-snapshot"
+version: "1.33.0"
 description: "Copy binaries from the packager image"
 
 execute:

--- a/images/modules/com.redhat.osl.cli.packager/install.sh
+++ b/images/modules/com.redhat.osl.cli.packager/install.sh
@@ -21,16 +21,16 @@ cd "${KN_WORK_DIR}"
 mv  "/tmp/LICENSE" .
 
 wget -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/amd64/linux/kn-workflow-linux-amd64"
-wget -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/ppc64le/linux/kn-workflow-linux-ppc64le"
-wget -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/s390x/linux/kn-workflow-linux-s390x"
+wget -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/arm64/linux/kn-workflow-linux-arm64"
 wget -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/amd64/windows/kn-workflow-windows-amd64.exe"
 wget -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/amd64/macos/kn-workflow-darwin-amd64"
+wget -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/arm64/macos/kn-workflow-darwin-arm64"
 
-chmod +x kn-workflow-linux-amd64 kn-workflow-linux-ppc64le kn-workflow-linux-s390x kn-workflow-windows-amd64.exe kn-workflow-darwin-amd64
+chmod +x kn-workflow-linux-amd64 kn-workflow-linux-arm64 kn-workflow-windows-amd64.exe kn-workflow-darwin-amd64 kn-workflow-darwin-arm64
 
 tar --transform='flags=r;s|kn-workflow-linux-amd64|kn|' -zcf kn-workflow-linux-amd64.tar.gz kn-workflow-linux-amd64 LICENSE
-tar --transform='flags=r;s|kn-workflow-linux-ppc64le|kn|' -zcf kn-workflow-linux-ppc64le.tar.gz kn-workflow-linux-ppc64le LICENSE
-tar --transform='flags=r;s|kn-workflow-linux-s390x|kn|' -zcf kn-workflow-linux-s390x.tar.gz kn-workflow-linux-s390x LICENSE
+tar --transform='flags=r;s|kn-workflow-linux-arm64|kn|' -zcf kn-workflow-linux-arm64.tar.gz kn-workflow-linux-arm64 LICENSE
 tar --transform='flags=r;s|kn-workflow-darwin-amd64|kn|' -zcf kn-workflow-macos-amd64.tar.gz kn-workflow-darwin-amd64 LICENSE
+tar --transform='flags=r;s|kn-workflow-darwin-arm64|kn|' -zcf kn-workflow-macos-arm64.tar.gz kn-workflow-darwin-arm64 LICENSE
 
 mkdir "${KN_WORK_DIR}/windows" && mv kn-workflow-windows-amd64.exe "${KN_WORK_DIR}/windows/kn.exe" && cp LICENSE "${KN_WORK_DIR}/windows/" && zip --quiet --junk-path - "${KN_WORK_DIR}/windows/*" > kn-workflow-windows-amd64.zip

--- a/images/modules/com.redhat.osl.cli.packager/install.sh
+++ b/images/modules/com.redhat.osl.cli.packager/install.sh
@@ -18,7 +18,7 @@ set -e
 mkdir -p "${KN_WORK_DIR}"
 cd "${KN_WORK_DIR}"
 
-mv  "/tmp/LICENSE" .
+mv  "/tmp/artifacts/LICENSE" .
 
 wget -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/amd64/linux/kn-workflow-linux-amd64"
 wget -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/arm64/linux/kn-workflow-linux-arm64"

--- a/images/modules/com.redhat.osl.cli.packager/install.sh
+++ b/images/modules/com.redhat.osl.cli.packager/install.sh
@@ -33,4 +33,4 @@ tar --transform='flags=r;s|kn-workflow-linux-arm64|kn|' -zcf kn-workflow-linux-a
 tar --transform='flags=r;s|kn-workflow-darwin-amd64|kn|' -zcf kn-workflow-macos-amd64.tar.gz kn-workflow-darwin-amd64 LICENSE
 tar --transform='flags=r;s|kn-workflow-darwin-arm64|kn|' -zcf kn-workflow-macos-arm64.tar.gz kn-workflow-darwin-arm64 LICENSE
 
-mkdir "${KN_WORK_DIR}/windows" && mv kn-workflow-windows-amd64.exe "${KN_WORK_DIR}/windows/kn.exe" && cp LICENSE "${KN_WORK_DIR}/windows/" && zip --quiet --junk-path - "${KN_WORK_DIR}/windows/*" > kn-workflow-windows-amd64.zip
+mkdir "${KN_WORK_DIR}/windows" && mv kn-workflow-windows-amd64.exe "${KN_WORK_DIR}/windows/kn.exe" && cp LICENSE "${KN_WORK_DIR}/windows/" && zip -jrq kn-workflow-windows-amd64.zip "${KN_WORK_DIR}/windows"

--- a/images/modules/com.redhat.osl.cli.packager/install.sh
+++ b/images/modules/com.redhat.osl.cli.packager/install.sh
@@ -20,11 +20,11 @@ cd "${KN_WORK_DIR}"
 
 mv  "/tmp/artifacts/LICENSE" .
 
-wget -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/amd64/linux/kn-workflow-linux-amd64"
-wget -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/arm64/linux/kn-workflow-linux-arm64"
-wget -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/amd64/windows/kn-workflow-windows-amd64.exe"
-wget -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/amd64/macos/kn-workflow-darwin-amd64"
-wget -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/arm64/macos/kn-workflow-darwin-arm64"
+wget -q -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/amd64/linux/kn-workflow-linux-amd64"
+wget -q -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/arm64/linux/kn-workflow-linux-arm64"
+wget -q -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/amd64/windows/kn-workflow-windows-amd64.exe"
+wget -q -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/amd64/macos/kn-workflow-darwin-amd64"
+wget -q -P "${KN_WORK_DIR}" "${KN_ARTIFACT_URL}/arm64/macos/kn-workflow-darwin-arm64"
 
 chmod +x kn-workflow-linux-amd64 kn-workflow-linux-arm64 kn-workflow-windows-amd64.exe kn-workflow-darwin-amd64 kn-workflow-darwin-arm64
 

--- a/images/modules/com.redhat.osl.cli.packager/module.yaml
+++ b/images/modules/com.redhat.osl.cli.packager/module.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: "com.redhat.osl.cli.packager"
-version: "1.33.0-snapshot"
+version: "1.33.0"
 description: "Download kn-workflow cli binaries from a given repository"
 
 packages:

--- a/images/modules/com.redhat.osl.cli.packager/module.yaml
+++ b/images/modules/com.redhat.osl.cli.packager/module.yaml
@@ -30,7 +30,6 @@ envs:
 args:
   - name: KN_ARTIFACT_URL
     description: "Base URL from where to download the artifacts"
-    example: "http://download.eng.bos.redhat.com/staging-cds/etera/openshift-serverless-clients/1/1.11/1.11.2-4/signed"
 artifacts:
   - name: LICENSE
     url: "https://raw.githubusercontent.com/kiegroup/kogito-serverless-operator/main/LICENSE"

--- a/images/osl-cli.yaml
+++ b/images/osl-cli.yaml
@@ -63,7 +63,6 @@ osbs:
         only:
         - x86_64
         - aarch64
-        - ppc64le
       compose:
         pulp_repos: true
   repository:

--- a/images/osl-cli.yaml
+++ b/images/osl-cli.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 - name: "packager"
-  version: 1.33.0-snapshot
+  version: "1.33.0"
   from: "registry.access.redhat.com/ubi8/ubi-minimal:latest"
   modules:
     repositories:
@@ -22,7 +22,7 @@
       - name: com.redhat.osl.cli.packager
 
 - name: "openshift-serverless-1/logic-kn-workflow-cli-artifacts-rhel8"
-  version: 1.33.0-snapshot
+  version: "1.33.0"
   description: "Red Hat OpenShift Serverless Logic 1 kn-workflow CLI artifacts"
   from: "registry.access.redhat.com/ubi8/ubi-minimal:latest"
   labels:
@@ -31,7 +31,7 @@
     - name: name
       value: "openshift-serverless-1/kn-workflow-cli-artifacts-rhel8"
     - name: version
-      value: "1.33.0-snapshot"
+      value: "1.33.0"
     - name: summary
       value: "Red Hat OpenShift Serverless Logic 1 kn-workflow CLI artifacts"
     - name: description

--- a/images/osl-cli.yaml
+++ b/images/osl-cli.yaml
@@ -51,20 +51,20 @@
       - name: com.redhat.osl.cli.artifacts
   run:
     user: 65532
-    
-packages:
-  manager: microdnf
-  content_sets_file: content_sets.yaml
 
-osbs:
-  configuration:
-    container:
-      platforms:
-        only:
-        - x86_64
-        - aarch64
-      compose:
-        pulp_repos: true
-  repository:
-    name: containers/openshift-serverless-1-logic-kn-workflow-cli-artifacts
-    branch: openshift-serverless-1.33-rhel-8    
+  packages:
+    manager: microdnf
+    content_sets_file: content_sets.yaml
+
+  osbs:
+    configuration:
+      container:
+        platforms:
+          only:
+          - x86_64
+          - aarch64
+        compose:
+          pulp_repos: true
+    repository:
+      name: containers/openshift-serverless-1-logic-kn-workflow-cli-artifacts
+      branch: openshift-serverless-1.33-rhel-8


### PR DESCRIPTION
As discussed in slack channel, for kn cli we should only support amd64 and aarch64, IBM P/Z is not supported and there will be no rpm build of it.

Related PRs:
- https://github.com/kiegroup/kogito-serverless-operator/pull/36
- https://github.com/kiegroup/kogito-serverless-operator/pull/58


**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>