### PR TITLE
[9.100.x-prod] SRVLOGIC-318: Data index ephemeral OSL deployment takes image from quiay.io/kiegroup instead of registry.redhat.io/openshift-serverless-1

### DIFF
--- a/bundle.prod/manifests/logic-operator-rhel8-controllers-config_v1_configmap.yaml
+++ b/bundle.prod/manifests/logic-operator-rhel8-controllers-config_v1_configmap.yaml
@@ -15,7 +15,7 @@ data:
     jobsServiceEphemeralImageTag: "registry.redhat.io/openshift-serverless-1/logic-jobs-service-ephemeral-rhel8:1.33.0"
     # The Data Index image to use, if empty the operator will use the default Apache Community one based on the current operator's version
     dataIndexPostgreSQLImageTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-postgresql-rhel8:1.33.0"
-    dataIndexEphemeralTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-ephemeral-rhel8:1.33.0"
+    dataIndexEphemeralImageTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-ephemeral-rhel8:1.33.0"
     # SonataFlow base builder image used in the internal Dockerfile to build workflow applications in preview profile
     # Order of precedence is:
     # 1. SonataFlowPlatform in the given namespace

--- a/bundle/manifests/sonataflow-operator-controllers-config_v1_configmap.yaml
+++ b/bundle/manifests/sonataflow-operator-controllers-config_v1_configmap.yaml
@@ -15,7 +15,7 @@ data:
     jobsServiceEphemeralImageTag: ""
     # The Data Index image to use, if empty the operator will use the default Apache Community one based on the current operator's version
     dataIndexPostgreSQLImageTag: ""
-    dataIndexEphemeralTag: ""
+    dataIndexEphemeralImageTag: ""
     # SonataFlow base builder image used in the internal Dockerfile to build workflow applications in preview profile
     # Order of precedence is:
     # 1. SonataFlowPlatform in the given namespace

--- a/config/manager/controllers_cfg.yaml
+++ b/config/manager/controllers_cfg.yaml
@@ -12,7 +12,7 @@ jobsServicePostgreSQLImageTag: ""
 jobsServiceEphemeralImageTag: ""
 # The Data Index image to use, if empty the operator will use the default Apache Community one based on the current operator's version
 dataIndexPostgreSQLImageTag: ""
-dataIndexEphemeralTag: ""
+dataIndexEphemeralImageTag: ""
 # SonataFlow base builder image used in the internal Dockerfile to build workflow applications in preview profile
 # Order of precedence is:
 # 1. SonataFlowPlatform in the given namespace

--- a/config/manager/prod/controllers_cfg.yaml
+++ b/config/manager/prod/controllers_cfg.yaml
@@ -12,7 +12,7 @@ jobsServicePostgreSQLImageTag: "registry.redhat.io/openshift-serverless-1/logic-
 jobsServiceEphemeralImageTag: "registry.redhat.io/openshift-serverless-1/logic-jobs-service-ephemeral-rhel8:1.33.0"
 # The Data Index image to use, if empty the operator will use the default Apache Community one based on the current operator's version
 dataIndexPostgreSQLImageTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-postgresql-rhel8:1.33.0"
-dataIndexEphemeralTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-ephemeral-rhel8:1.33.0"
+dataIndexEphemeralImageTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-ephemeral-rhel8:1.33.0"
 # SonataFlow base builder image used in the internal Dockerfile to build workflow applications in preview profile
 # Order of precedence is:
 # 1. SonataFlowPlatform in the given namespace

--- a/operator.yaml
+++ b/operator.yaml
@@ -27011,7 +27011,7 @@ data:
     jobsServiceEphemeralImageTag: ""
     # The Data Index image to use, if empty the operator will use the default Apache Community one based on the current operator's version
     dataIndexPostgreSQLImageTag: ""
-    dataIndexEphemeralTag: ""
+    dataIndexEphemeralImageTag: ""
     # SonataFlow base builder image used in the internal Dockerfile to build workflow applications in preview profile
     # Order of precedence is:
     # 1. SonataFlowPlatform in the given namespace


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>