### PR TITLE
[main] SRVLOGIC-318: Data index ephemeral OSL deployment takes image from quiay.io/kiegroup instead of registry.redhat.io/openshift-serverless-1

### DIFF
--- a/bundle.prod/manifests/logic-operator-rhel8-controllers-config_v1_configmap.yaml
+++ b/bundle.prod/manifests/logic-operator-rhel8-controllers-config_v1_configmap.yaml
@@ -11,11 +11,11 @@ data:
     # Default image used internally by the Operator Managed Kaniko builder to create the executor pods
     kanikoExecutorImageTag: gcr.io/kaniko-project/executor:v1.9.0
     # The Jobs Service image to use, if empty the operator will use the default Apache Community one based on the current operator's version
-    jobsServicePostgreSQLImageTag: ""
-    jobsServiceEphemeralImageTag: ""
+    jobsServicePostgreSQLImageTag: "registry.redhat.io/openshift-serverless-1/logic-jobs-service-postgresql-rhel8:1.33.0"
+    jobsServiceEphemeralImageTag: "registry.redhat.io/openshift-serverless-1/logic-jobs-service-ephemeral-rhel8:1.33.0"
     # The Data Index image to use, if empty the operator will use the default Apache Community one based on the current operator's version
-    dataIndexPostgreSQLImageTag: ""
-    dataIndexEphemeralImageTag: ""
+    dataIndexPostgreSQLImageTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-postgresql-rhel8:1.33.0"
+    dataIndexEphemeralImageTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-ephemeral-rhel8:1.33.0"
     # SonataFlow base builder image used in the internal Dockerfile to build workflow applications in preview profile
     # Order of precedence is:
     # 1. SonataFlowPlatform in the given namespace
@@ -23,24 +23,24 @@ data:
     # 3. The FROM in the Dockerfile in the operator's namespace "sonataflow-operator-builder-config" configMap.
     # If 1 or 2, the FROM tag will be replaced by the tag se there.
     # If empty the operator will use the default Apache Community one based on the current operator's version.
-    sonataFlowBaseBuilderImageTag: ""
+    sonataFlowBaseBuilderImageTag: "registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.33.0"
     # The image to use to deploy SonataFlow workflow images in devmode profile.
     # If empty the operator will use the default Apache Community one based on the current operator's version.
-    sonataFlowDevModeImageTag: ""
+    sonataFlowDevModeImageTag: "registry.redhat.io/openshift-serverless-1/logic-swf-devmode-rhel8:1.33.0"
     # The default name of the builder configMap in the operator's namespace
-    builderConfigMapName: "sonataflow-operator-builder-config"
+    builderConfigMapName: "logic-operator-rhel8-builder-config"
     # Quarkus extensions required for workflows persistence. These extensions are used by the SonataFlow build system,
     # in cases where the workflow being built has configured postgresql persistence.
     postgreSQLPersistenceExtensions:
       - groupId: io.quarkus
         artifactId: quarkus-jdbc-postgresql
-        version: 3.8.4
+        version: 3.8.4.redhat-00002
       - groupId: io.quarkus
         artifactId: quarkus-agroal
-        version: 3.8.4
+        version: 3.8.4.redhat-00002
       - groupId: org.kie
         artifactId: kie-addons-quarkus-persistence-jdbc
-        version: 999-SNAPSHOT
+        version: 9.100.0.redhat-00004
 kind: ConfigMap
 metadata:
-  name: sonataflow-operator-controllers-config
+  name: logic-operator-rhel8-controllers-config

--- a/config/manager/controllers_cfg.yaml
+++ b/config/manager/controllers_cfg.yaml
@@ -12,7 +12,7 @@ jobsServicePostgreSQLImageTag: ""
 jobsServiceEphemeralImageTag: ""
 # The Data Index image to use, if empty the operator will use the default Apache Community one based on the current operator's version
 dataIndexPostgreSQLImageTag: ""
-dataIndexEphemeralTag: ""
+dataIndexEphemeralImageTag: ""
 # SonataFlow base builder image used in the internal Dockerfile to build workflow applications in preview profile
 # Order of precedence is:
 # 1. SonataFlowPlatform in the given namespace

--- a/config/manager/prod/controllers_cfg.yaml
+++ b/config/manager/prod/controllers_cfg.yaml
@@ -12,7 +12,7 @@ jobsServicePostgreSQLImageTag: "registry.redhat.io/openshift-serverless-1/logic-
 jobsServiceEphemeralImageTag: "registry.redhat.io/openshift-serverless-1/logic-jobs-service-ephemeral-rhel8:1.33.0"
 # The Data Index image to use, if empty the operator will use the default Apache Community one based on the current operator's version
 dataIndexPostgreSQLImageTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-postgresql-rhel8:1.33.0"
-dataIndexEphemeralTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-ephemeral-rhel8:1.33.0"
+dataIndexEphemeralImageTag: "registry.redhat.io/openshift-serverless-1/logic-data-index-ephemeral-rhel8:1.33.0"
 # SonataFlow base builder image used in the internal Dockerfile to build workflow applications in preview profile
 # Order of precedence is:
 # 1. SonataFlowPlatform in the given namespace

--- a/operator.yaml
+++ b/operator.yaml
@@ -27011,7 +27011,7 @@ data:
     jobsServiceEphemeralImageTag: ""
     # The Data Index image to use, if empty the operator will use the default Apache Community one based on the current operator's version
     dataIndexPostgreSQLImageTag: ""
-    dataIndexEphemeralTag: ""
+    dataIndexEphemeralImageTag: ""
     # SonataFlow base builder image used in the internal Dockerfile to build workflow applications in preview profile
     # Order of precedence is:
     # 1. SonataFlowPlatform in the given namespace


### PR DESCRIPTION

<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>