### PR TITLE
[main] SRVLOGIC-319: Supporting service don't inherit platform persistence when the current service persistence is empty

### DIFF
--- a/controllers/platform/services/services.go
+++ b/controllers/platform/services/services.go
@@ -227,7 +227,7 @@ func (d DataIndexHandler) hasPostgreSQLConfigured() bool {
 
 func (d DataIndexHandler) ConfigurePersistence(containerSpec *corev1.Container) *corev1.Container {
 	if d.hasPostgreSQLConfigured() {
-		p := persistence.RetrieveConfiguration(d.platform.Spec.Services.DataIndex.Persistence, d.platform.Spec.Persistence, d.GetServiceName())
+		p := persistence.RetrievePostgreSQLConfiguration(d.platform.Spec.Services.DataIndex.Persistence, d.platform.Spec.Persistence, d.GetServiceName())
 		c := containerSpec.DeepCopy()
 		c.Image = d.GetServiceImageName(constants.PersistenceTypePostgreSQL)
 		c.Env = append(c.Env, persistence.ConfigurePostgreSQLEnv(p.PostgreSQL, d.GetServiceName(), d.platform.Namespace)...)
@@ -397,11 +397,10 @@ func (j JobServiceHandler) hasPostgreSQLConfigured() bool {
 }
 
 func (j JobServiceHandler) ConfigurePersistence(containerSpec *corev1.Container) *corev1.Container {
-
 	if j.hasPostgreSQLConfigured() {
 		c := containerSpec.DeepCopy()
 		c.Image = j.GetServiceImageName(constants.PersistenceTypePostgreSQL)
-		p := persistence.RetrieveConfiguration(j.platform.Spec.Services.JobService.Persistence, j.platform.Spec.Persistence, j.GetServiceName())
+		p := persistence.RetrievePostgreSQLConfiguration(j.platform.Spec.Services.JobService.Persistence, j.platform.Spec.Persistence, j.GetServiceName())
 		c.Env = append(c.Env, persistence.ConfigurePostgreSQLEnv(p.PostgreSQL, j.GetServiceName(), j.platform.Namespace)...)
 		// Specific to Job Service
 		c.Env = append(c.Env, corev1.EnvVar{Name: "QUARKUS_FLYWAY_MIGRATE_AT_START", Value: "true"})
@@ -423,7 +422,7 @@ func (j JobServiceHandler) GenerateServiceProperties() (*properties.Properties, 
 	props.Set(constants.JobServiceKafkaSmallRyeHealthProperty, "false")
 	// add data source reactive URL
 	if j.hasPostgreSQLConfigured() {
-		p := persistence.RetrieveConfiguration(j.platform.Spec.Services.JobService.Persistence, j.platform.Spec.Persistence, j.GetServiceName())
+		p := persistence.RetrievePostgreSQLConfiguration(j.platform.Spec.Services.JobService.Persistence, j.platform.Spec.Persistence, j.GetServiceName())
 		dataSourceReactiveURL, err := generateReactiveURL(p.PostgreSQL, j.GetServiceName(), j.platform.Namespace, constants.DefaultDatabaseName, constants.DefaultPostgreSQLPort)
 		if err != nil {
 			return nil, err

--- a/controllers/profiles/common/persistence/persistence_suite_test.go
+++ b/controllers/profiles/common/persistence/persistence_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2024 Apache Software Foundation (ASF)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package persistence
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPersistence(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Persistence Suite")
+}

--- a/controllers/profiles/common/persistence/postgresql.go
+++ b/controllers/profiles/common/persistence/postgresql.go
@@ -112,6 +112,19 @@ func RetrieveConfiguration(primary *v1alpha08.PersistenceOptionsSpec, platformPe
 	if platformPersistence == nil {
 		return nil
 	}
+	return buildPersistenceOptionsSpec(platformPersistence, schema)
+}
+
+// RetrievePostgreSQLConfiguration return the PersistenceOptionsSpec considering that postgresql is the database manager
+// to look for. Gives priority to the primary configuration.
+func RetrievePostgreSQLConfiguration(primary *v1alpha08.PersistenceOptionsSpec, platformPersistence *v1alpha08.PlatformPersistenceOptionsSpec, schema string) *v1alpha08.PersistenceOptionsSpec {
+	if primary != nil && primary.PostgreSQL != nil {
+		return primary
+	}
+	return buildPersistenceOptionsSpec(platformPersistence, schema)
+}
+
+func buildPersistenceOptionsSpec(platformPersistence *v1alpha08.PlatformPersistenceOptionsSpec, schema string) *v1alpha08.PersistenceOptionsSpec {
 	c := &v1alpha08.PersistenceOptionsSpec{}
 	if platformPersistence.PostgreSQL != nil {
 		c.PostgreSQL = &v1alpha08.PersistencePostgreSQL{

--- a/controllers/profiles/common/persistence/postgresql_test.go
+++ b/controllers/profiles/common/persistence/postgresql_test.go
@@ -1,0 +1,146 @@
+// Copyright 2024 Apache Software Foundation (ASF)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package persistence
+
+import (
+	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	primaryPostgreSQLJdbc = "jdbc:postgresql://host:port/database?currentSchema=primary-database"
+
+	platformPostgreSQLJdbc = "jdbc:postgresql://host:port/database?currentSchema=platform-database"
+	schemaName             = "my-schema"
+)
+
+var (
+	primaryPostgreSQLSecret = operatorapi.PostgreSQLSecretOptions{
+		Name: "primary-secret",
+	}
+	primaryPostreSQLService = operatorapi.PostgreSQLServiceOptions{
+		SQLServiceOptions: &operatorapi.SQLServiceOptions{Name: "primary-service"},
+		DatabaseSchema:    "primary-schema",
+	}
+	plaformPostgreSQLSecret = operatorapi.PostgreSQLSecretOptions{
+		Name: "platform-secret",
+	}
+	platformPostreSQLService = operatorapi.SQLServiceOptions{
+		Name: "platform-service",
+	}
+)
+
+var _ = Describe("RetrievePostgreSQLConfiguration", func() {
+	DescribeTable("calculation",
+		func(primary *operatorapi.PersistenceOptionsSpec,
+			platformPersistence *operatorapi.PlatformPersistenceOptionsSpec,
+			schema string,
+			expectedConfig *operatorapi.PersistenceOptionsSpec) {
+			result := RetrievePostgreSQLConfiguration(primary, platformPersistence, schema)
+			Expect(expectedConfig).To(Equal(result))
+		},
+		Entry("primary is postgresql with JdbcUrl", buildPrimaryIsPostgreSQLWithJdbcUrl(),
+			buildPlatformIsPostgreSQLWithJdbcUrl(),
+			schemaName,
+			buildPrimaryIsPostgreSQLWithJdbcUrl()),
+		Entry("primary is postgresql ServiceRef", buildPrimaryIsPostgreSQLWithServiceRef(),
+			buildPlatformIsPostgreSQLWithJdbcUrl(),
+			schemaName,
+			buildPrimaryIsPostgreSQLWithServiceRef()),
+		Entry("primary is nil, platform with JdbcUrl",
+			nil,
+			buildPlatformIsPostgreSQLWithJdbcUrl(),
+			schemaName,
+			&operatorapi.PersistenceOptionsSpec{
+				PostgreSQL: &operatorapi.PersistencePostgreSQL{
+					SecretRef: plaformPostgreSQLSecret,
+					JdbcUrl:   platformPostgreSQLJdbc,
+				},
+			}),
+		Entry("primary is empty, platform with JdbcUrl",
+			&operatorapi.PersistenceOptionsSpec{},
+			buildPlatformIsPostgreSQLWithJdbcUrl(),
+			schemaName,
+			&operatorapi.PersistenceOptionsSpec{
+				PostgreSQL: &operatorapi.PersistencePostgreSQL{
+					SecretRef: plaformPostgreSQLSecret,
+					JdbcUrl:   platformPostgreSQLJdbc,
+				},
+			}),
+		Entry("primary is nil, platform with ServiceRef",
+			nil,
+			buildPlatformIsPostgreSQLWithServiceRef(),
+			schemaName,
+			&operatorapi.PersistenceOptionsSpec{
+				PostgreSQL: &operatorapi.PersistencePostgreSQL{
+					ServiceRef: &operatorapi.PostgreSQLServiceOptions{
+						SQLServiceOptions: &platformPostreSQLService,
+						DatabaseSchema:    schemaName,
+					},
+					SecretRef: plaformPostgreSQLSecret,
+				},
+			}),
+		Entry("primary is empty, platform with ServiceRef",
+			&operatorapi.PersistenceOptionsSpec{},
+			buildPlatformIsPostgreSQLWithServiceRef(),
+			schemaName,
+			&operatorapi.PersistenceOptionsSpec{
+				PostgreSQL: &operatorapi.PersistencePostgreSQL{
+					ServiceRef: &operatorapi.PostgreSQLServiceOptions{
+						SQLServiceOptions: &platformPostreSQLService,
+						DatabaseSchema:    schemaName,
+					},
+					SecretRef: plaformPostgreSQLSecret,
+				},
+			}),
+	)
+})
+
+func buildPrimaryIsPostgreSQLWithJdbcUrl() *operatorapi.PersistenceOptionsSpec {
+	return &operatorapi.PersistenceOptionsSpec{
+		PostgreSQL: &operatorapi.PersistencePostgreSQL{
+			JdbcUrl:   primaryPostgreSQLJdbc,
+			SecretRef: primaryPostgreSQLSecret,
+		},
+	}
+}
+
+func buildPrimaryIsPostgreSQLWithServiceRef() *operatorapi.PersistenceOptionsSpec {
+	return &operatorapi.PersistenceOptionsSpec{
+		PostgreSQL: &operatorapi.PersistencePostgreSQL{
+			ServiceRef: &primaryPostreSQLService,
+			SecretRef:  primaryPostgreSQLSecret,
+		},
+	}
+}
+
+func buildPlatformIsPostgreSQLWithJdbcUrl() *operatorapi.PlatformPersistenceOptionsSpec {
+	return &operatorapi.PlatformPersistenceOptionsSpec{
+		PostgreSQL: &operatorapi.PlatformPersistencePostgreSQL{
+			JdbcUrl:   platformPostgreSQLJdbc,
+			SecretRef: plaformPostgreSQLSecret,
+		},
+	}
+}
+
+func buildPlatformIsPostgreSQLWithServiceRef() *operatorapi.PlatformPersistenceOptionsSpec {
+	return &operatorapi.PlatformPersistenceOptionsSpec{
+		PostgreSQL: &operatorapi.PlatformPersistencePostgreSQL{
+			ServiceRef: &platformPostreSQLService,
+			SecretRef:  plaformPostgreSQLSecret,
+		},
+	}
+}


### PR DESCRIPTION

(cherry picked from commit b1426e630b261e52792721f283113877355af789)

<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>