### PR TITLE
[9.100.x-prod] SRVLOGIC-329: Update prod files that are using latest tag to 1.33.0 tag

### DIFF
--- a/bundle.prod/manifests/logic-operator-rhel8-builder-config_v1_configmap.yaml
+++ b/bundle.prod/manifests/logic-operator-rhel8-builder-config_v1_configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   DEFAULT_WORKFLOW_EXTENSION: .sw.json
-  Dockerfile: "FROM registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:latest
+  Dockerfile: "FROM registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.33.0
     AS builder\n\n# variables that can be overridden by the builder\n# To add a Quarkus
     extension to your application\nARG QUARKUS_EXTENSIONS\n# Args to pass to the Quarkus
     CLI add extension command\nARG QUARKUS_ADD_EXTENSION_ARGS\n# Additional java/mvn

--- a/config/manager/prod/SonataFlow-Builder.containerfile
+++ b/config/manager/prod/SonataFlow-Builder.containerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:latest AS builder
+FROM registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.33.0 AS builder
 
 # variables that can be overridden by the builder
 # To add a Quarkus extension to your application


### PR DESCRIPTION
**Description of the change:**
https://issues.redhat.com/browse/SRVLOGIC-329

**Motivation for the change:**
This was identified when testing workflow deployments in clusterplatform that referencees DI and JS in different namespace.
Workflow built in this SFCP namespace use `latest` tag when inspecting the build logs
`Pulling image url-to-repository/repo/image:latest....`

Workflows in namespace of SP are using correct version.

let me know, there is also one more file with latest tag, not sure if it is used.