### PR TITLE
[9.101.x-prod] kie-kogito-serverless-operator-533: Builder image is not used according to the configuration semantic (#534)

### DIFF
--- a/controllers/platform/platformutils_test.go
+++ b/controllers/platform/platformutils_test.go
@@ -24,10 +24,16 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
+	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/cfg"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/apache/incubator-kie-kogito-serverless-operator/test"
 )
+
+const dockerFile = "FROM docker.io/apache/default-test-kie-sonataflow-builder:main AS builder\n\n# ETC, \n\n# ETC, \n\n# ETC"
 
 func TestSonataFlowBuildController(t *testing.T) {
 	platform := test.GetBasePlatform()
@@ -48,4 +54,50 @@ func TestSonataFlowBuildController(t *testing.T) {
 	foundProductized, err := regexp.MatchString("FROM registry.access.redhat.com/openshift-serverless-1/logic-swf-builder-rhel8 AS builder", resProductized)
 	assert.NoError(t, err)
 	assert.True(t, foundProductized)
+}
+
+func TestGetCustomizedBuilderDockerfile_NoBaseImageCustomization(t *testing.T) {
+	sfp := v1alpha08.SonataFlowPlatform{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec:       v1alpha08.SonataFlowPlatformSpec{},
+		Status:     v1alpha08.SonataFlowPlatformStatus{},
+	}
+	customizedDockerfile := GetCustomizedBuilderDockerfile(dockerFile, sfp)
+	assert.Equal(t, dockerFile, customizedDockerfile)
+}
+
+func TestGetCustomizedBuilderDockerfile_BaseImageCustomizationFromPlatform(t *testing.T) {
+	sfp := v1alpha08.SonataFlowPlatform{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: v1alpha08.SonataFlowPlatformSpec{
+			Build: v1alpha08.BuildPlatformSpec{
+				Template: v1alpha08.BuildTemplate{},
+				Config: v1alpha08.BuildPlatformConfig{
+					BaseImage: "docker.io/apache/platfom-sonataflow-builder:main",
+				},
+			},
+		},
+		Status: v1alpha08.SonataFlowPlatformStatus{},
+	}
+
+	expectedDockerFile := "FROM docker.io/apache/platfom-sonataflow-builder:main AS builder\n\n# ETC, \n\n# ETC, \n\n# ETC"
+	customizedDockerfile := GetCustomizedBuilderDockerfile(dockerFile, sfp)
+	assert.Equal(t, expectedDockerFile, customizedDockerfile)
+}
+
+func TestGetCustomizedBuilderDockerfile_BaseImageCustomizationFromControllersConfig(t *testing.T) {
+	sfp := v1alpha08.SonataFlowPlatform{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec:       v1alpha08.SonataFlowPlatformSpec{},
+		Status:     v1alpha08.SonataFlowPlatformStatus{},
+	}
+
+	_, err := cfg.InitializeControllersCfgAt("../cfg/testdata/controllers-cfg-test.yaml")
+	assert.NoError(t, err)
+	expectedDockerFile := "FROM local/sonataflow-builder:1.0.0 AS builder\n\n# ETC, \n\n# ETC, \n\n# ETC"
+	customizedDockerfile := GetCustomizedBuilderDockerfile(dockerFile, sfp)
+	assert.Equal(t, expectedDockerFile, customizedDockerfile)
 }


### PR DESCRIPTION

<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>