### PR TITLE
[9.101.x-prod][SRVLOGIC-413] - Add replaces attribute to CSV

### DIFF
--- a/Makefile.prod
+++ b/Makefile.prod
@@ -223,14 +223,14 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v4.5.2
+KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.9.2
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
-	test -s $(LOCALBIN)/kustomize || GO111MODULE=on GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v4@$(KUSTOMIZE_VERSION)
+	test -s $(LOCALBIN)/kustomize || GO111MODULE=on GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION)
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.

--- a/bundle.prod/manifests/logic-operator-rhel8.clusterserviceversion.yaml
+++ b/bundle.prod/manifests/logic-operator-rhel8.clusterserviceversion.yaml
@@ -893,4 +893,5 @@ spec:
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat
+  replaces: logic-operator-rhel8.v1.33.0
   version: 1.34.0

--- a/bundle.prod/manifests/sonataflow.org_sonataflows.yaml
+++ b/bundle.prod/manifests/sonataflow.org_sonataflows.yaml
@@ -80,8 +80,8 @@ spec:
                   constants:
                     additionalProperties:
                       description: RawMessage is a raw encoded JSON value. It implements
-                        Marshaler and Unmarshaler and can be used to delay JSON decoding
-                        or precompute a JSON encoding.
+                        [Marshaler] and [Unmarshaler] and can be used to delay JSON
+                        decoding or precompute a JSON encoding.
                       format: byte
                       type: string
                     description: Constants Workflow constants are used to define static,

--- a/bundle/manifests/sonataflow.org_sonataflows.yaml
+++ b/bundle/manifests/sonataflow.org_sonataflows.yaml
@@ -80,8 +80,8 @@ spec:
                   constants:
                     additionalProperties:
                       description: RawMessage is a raw encoded JSON value. It implements
-                        Marshaler and Unmarshaler and can be used to delay JSON decoding
-                        or precompute a JSON encoding.
+                        [Marshaler] and [Unmarshaler] and can be used to delay JSON
+                        decoding or precompute a JSON encoding.
                       format: byte
                       type: string
                     description: Constants Workflow constants are used to define static,

--- a/config/crd/bases/sonataflow.org_sonataflows.yaml
+++ b/config/crd/bases/sonataflow.org_sonataflows.yaml
@@ -81,8 +81,8 @@ spec:
                   constants:
                     additionalProperties:
                       description: RawMessage is a raw encoded JSON value. It implements
-                        Marshaler and Unmarshaler and can be used to delay JSON decoding
-                        or precompute a JSON encoding.
+                        [Marshaler] and [Unmarshaler] and can be used to delay JSON
+                        decoding or precompute a JSON encoding.
                       format: byte
                       type: string
                     description: Constants Workflow constants are used to define static,

--- a/config/manifests/prod/bases/logic-operator-rhel8.clusterserviceversion.yaml
+++ b/config/manifests/prod/bases/logic-operator-rhel8.clusterserviceversion.yaml
@@ -283,4 +283,5 @@ spec:
     name: IMAGE_LOGIC_SWF_BUILDER
   - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56
     name: IMAGE_KUBE_RBAC_PROXY
+  replaces: logic-operator-rhel8.v1.33.0
   version: 0.0.0

--- a/operator.yaml
+++ b/operator.yaml
@@ -16983,8 +16983,8 @@ spec:
                   constants:
                     additionalProperties:
                       description: RawMessage is a raw encoded JSON value. It implements
-                        Marshaler and Unmarshaler and can be used to delay JSON decoding
-                        or precompute a JSON encoding.
+                        [Marshaler] and [Unmarshaler] and can be used to delay JSON
+                        decoding or precompute a JSON encoding.
                       format: byte
                       type: string
                     description: Constants Workflow constants are used to define static,


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
Adds the `replaces` tag to start the upgrade graph in the OLM catalog.

**Motivation for the change:**
Fix https://issues.redhat.com/browse/SRVLOGIC-413

There's a small change by upgrading `kustomize` since, in my local version, v4 won't work anymore. I'll upgrade upstream too.

**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>