### PR TITLE
[9.102.x-prod] SRVLOGIC-468: Operator CR1 build is missing the events grouping configuration

### DIFF
--- a/bundle.prod/manifests/logic-operator-rhel8-controllers-config_v1_configmap.yaml
+++ b/bundle.prod/manifests/logic-operator-rhel8-controllers-config_v1_configmap.yaml
@@ -58,6 +58,14 @@ data:
       - groupId: org.kie
         artifactId: kie-addons-quarkus-persistence-jdbc
         version: 9.102.0.redhat-00004
+    # If true, the workflow deployments will be configured to send accumulated workflow status change events to the Data
+    # Index Service reducing the number of produced events. Set to false to send individual events.
+    kogitoEventsGrouping: true
+    # If true, the accumulated workflow status change events will be sent in binary mode. (reduces the evens size)
+    kogitoEventsGroupingBinary: true
+    # If true, the accumulated workflow status change events, when sent in binary mode, will be gzipped at the cost of
+    # some performance.
+    kogitoEventsGroupingCompress: false
 kind: ConfigMap
 metadata:
   name: logic-operator-rhel8-controllers-config

--- a/config/manager/prod/controllers_cfg.yaml
+++ b/config/manager/prod/controllers_cfg.yaml
@@ -55,3 +55,11 @@ postgreSQLPersistenceExtensions:
   - groupId: org.kie
     artifactId: kie-addons-quarkus-persistence-jdbc
     version: 9.102.0.redhat-00004
+# If true, the workflow deployments will be configured to send accumulated workflow status change events to the Data
+# Index Service reducing the number of produced events. Set to false to send individual events.
+kogitoEventsGrouping: true
+# If true, the accumulated workflow status change events will be sent in binary mode. (reduces the evens size)
+kogitoEventsGroupingBinary: true
+# If true, the accumulated workflow status change events, when sent in binary mode, will be gzipped at the cost of
+# some performance.
+kogitoEventsGroupingCompress: false


### PR DESCRIPTION
Related PRs:
- https://github.com/kiegroup/kogito-serverless-operator/pull/102
- https://github.com/kiegroup/kogito-serverless-operator/pull/103

<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>